### PR TITLE
Fix gemspec warnings for gem publishing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     coolhand (0.3.0)
-      base64
+      base64 (~> 0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/coolhand-ruby.gemspec
+++ b/coolhand-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/Coolhand-Labs/coolhand-ruby"
-  spec.metadata["changelog_uri"] = "https://github.com/Coolhand-Labs/coolhand-ruby"
+  spec.metadata["changelog_uri"] = "https://github.com/Coolhand-Labs/coolhand-ruby/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
-  spec.add_dependency "base64"
+  spec.add_dependency "base64", "~> 0.2"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary

Fixes two RubyGems build warnings that appeared when running `gem build`.

**Changes:**
- Bounded `base64` dependency to `~> 0.2` (removes open-ended dependency warning)
- Updated `changelog_uri` to point directly to CHANGELOG.md (fixes duplicate URI warning)

**Impact:** `gem build` now completes cleanly without warnings, improving gem publishing quality and compliance with RubyGems best practices.