### PR TITLE
Add config.base_url for self-hosted deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### ✨ New Features
+- **`config.base_url`** - Configurable API destination for self-hosted deployments. Defaults to `https://coolhandlabs.com/api`; set to any `https://` URL to redirect logs and feedback POSTs to your own backend. `http://localhost` and `http://127.0.0.1` are also accepted for local development. Trailing slashes are normalized automatically.
+
+### 💔 Breaking Changes
+- **`config.base_url` validation** - `Coolhand.configure` now raises `Coolhand::Error` if `base_url` is set to a plain `http://` URL (non-localhost). Previously any string was accepted silently. If you were pointing at an internal `http://` host (e.g. `http://logs.internal/api`), you will need to either enable TLS on that host or use an `https://` proxy in front of it.
 
 ## [0.3.0] - 2026-03-01
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ end
 - ⚡ **Performance optimized** - Negligible overhead via async logging
 - 🛡️ **Future-proof** - Automatically captures new AI calls added by your team
 
+## Self-Hosted Deployments
+
+For compliance, data-residency, or cost reasons you can run your own Coolhand-compatible endpoint and point the SDK at it via `config.base_url`:
+
+```ruby
+Coolhand.configure do |config|
+  config.api_key  = ENV['COOLHAND_API_KEY']
+  config.base_url = ENV['COOLHAND_BASE_URL']  # e.g. "https://coolhand.internal.example.com/api"
+end
+```
+
+When `base_url` is unset the SDK defaults to `https://coolhandlabs.com/api` and behaviour is unchanged.
+
+**Accepted values:**
+- Any `https://` URL — required for production use
+- `http://localhost` or `http://127.0.0.1` — accepted for local development only
+
+**Trailing slashes** are stripped automatically, so `"https://example.com/api/"` and `"https://example.com/api"` are equivalent.
+
+The SDK raises `Coolhand::Error` at configure time if `base_url` is set to a plain `http://` URL pointing at a non-localhost host.
+
 ## Feedback API
 
 Collect feedback on LLM responses to improve model performance.

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "uri"
 
 module Coolhand
   # Handles all configuration settings for the gem.
@@ -9,8 +10,8 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
-    attr_accessor :api_key, :environment, :silent, :base_url, :debug_mode, :capture, :exclude_api_patterns
-    attr_reader :intercept_addresses
+    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
+    attr_reader :intercept_addresses, :base_url
 
     def initialize
       # Set defaults
@@ -20,7 +21,7 @@ module Coolhand
       @intercept_addresses = ["api.openai.com", "api.anthropic.com", "api.elevenlabs.io",
                               "generativelanguage.googleapis.com",
                               ":generateContent", ":streamGenerateContent"]
-      @base_url = "https://coolhandlabs.com/api"
+      self.base_url = "https://coolhandlabs.com/api"
       @debug_mode = false
       @capture = true
       @exclude_api_patterns = DEFAULT_EXCLUDE_API_PATTERNS.dup
@@ -31,6 +32,10 @@ module Coolhand
       return if value.nil? || (value.is_a?(Array) && value.empty?)
 
       @intercept_addresses = value.is_a?(Array) ? value : [value]
+    end
+
+    def base_url=(value)
+      @base_url = value&.sub(/\/+\z/, "")
     end
 
     def validate!
@@ -45,6 +50,24 @@ module Coolhand
         Coolhand.log "❌ Coolhand Error: Intercept addresses cannot be empty. Please set it in the configuration."
         raise Error, "Intercept addresses cannot be empty"
       end
+
+      unless valid_base_url?(base_url)
+        Coolhand.log "❌ Coolhand Error: base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)."
+        raise Error, "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
+      end
+    end
+
+    private
+
+    def valid_base_url?(url)
+      return false if url.nil? || url.empty?
+
+      parsed = URI.parse(url)
+      return true if parsed.scheme == "https"
+
+      parsed.scheme == "http" && (parsed.host == "localhost" || parsed.host == "127.0.0.1")
+    rescue URI::InvalidURIError
+      false
     end
   end
 end

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -10,6 +10,9 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
+    BASE_URL_ERROR_MSG = "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
+    LOOPBACK_HOSTS = %w[localhost 127.0.0.1 ::1].freeze
+
     attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
     attr_reader :intercept_addresses, :base_url
 
@@ -35,7 +38,10 @@ module Coolhand
     end
 
     def base_url=(value)
-      @base_url = value&.sub(%r{/+\z}, "")
+      stripped = value&.sub(%r{/+\z}, "")
+      raise Error, BASE_URL_ERROR_MSG unless stripped.nil? || valid_base_url?(stripped)
+
+      @base_url = stripped
     end
 
     def validate!
@@ -52,9 +58,8 @@ module Coolhand
       end
 
       unless valid_base_url?(base_url)
-        msg = "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
-        Coolhand.log "❌ Coolhand Error: #{msg}"
-        raise Error, msg
+        Coolhand.log "❌ Coolhand Error: #{BASE_URL_ERROR_MSG}"
+        raise Error, BASE_URL_ERROR_MSG
       end
     end
 
@@ -64,9 +69,12 @@ module Coolhand
       return false if url.nil? || url.empty?
 
       parsed = URI.parse(url)
+      host = parsed.hostname&.downcase
+
+      return false if host.nil? || host.empty?
       return true if parsed.scheme == "https"
 
-      parsed.scheme == "http" && %w[localhost 127.0.0.1].include?(parsed.host)
+      parsed.scheme == "http" && LOOPBACK_HOSTS.include?(host)
     rescue URI::InvalidURIError
       false
     end

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -35,7 +35,7 @@ module Coolhand
     end
 
     def base_url=(value)
-      @base_url = value&.sub(/\/+\z/, "")
+      @base_url = value&.sub(%r{/+\z}, "")
     end
 
     def validate!
@@ -52,8 +52,9 @@ module Coolhand
       end
 
       unless valid_base_url?(base_url)
-        Coolhand.log "❌ Coolhand Error: base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)."
-        raise Error, "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
+        msg = "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
+        Coolhand.log "❌ Coolhand Error: #{msg}"
+        raise Error, msg
       end
     end
 
@@ -65,7 +66,7 @@ module Coolhand
       parsed = URI.parse(url)
       return true if parsed.scheme == "https"
 
-      parsed.scheme == "http" && (parsed.host == "localhost" || parsed.host == "127.0.0.1")
+      parsed.scheme == "http" && %w[localhost 127.0.0.1].include?(parsed.host)
     rescue URI::InvalidURIError
       false
     end

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Coolhand::ApiService do
     end
   end
 
+  describe "custom base_url" do
+    it "uses the configured base_url to build api_endpoint" do
+      Coolhand.configuration.base_url = "https://self-hosted.example.com/api"
+      service = described_class.new
+      expect(service.api_endpoint).to eq("https://self-hosted.example.com/api/v2/llm_request_logs")
+    end
+
+    it "strips trailing slash when building api_endpoint" do
+      Coolhand.configuration.base_url = "https://self-hosted.example.com/api/"
+      service = described_class.new
+      expect(service.api_endpoint).to eq("https://self-hosted.example.com/api/v2/llm_request_logs")
+    end
+  end
+
   describe "debug_mode with send_llm_request_log" do
     let(:service) { described_class.new }
     let(:request_data) do

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe Coolhand::ApiService do
       service = described_class.new
       expect(service.api_endpoint).to eq("https://self-hosted.example.com/api/v2/llm_request_logs")
     end
+
+    it "sends the HTTP request to the custom host, not the default" do
+      Coolhand.configuration.base_url = "https://self-hosted.example.com/api"
+      stub_request(:post, "https://self-hosted.example.com/api/v2/llm_request_logs")
+        .to_return(status: 200, body: JSON.generate({ id: 99 }), headers: { "Content-Type" => "application/json" })
+
+      described_class.new.send_llm_request_log(
+        method: "POST",
+        url: "https://api.openai.com/v1/chat/completions",
+        request_body: {},
+        response_body: {},
+        status_code: 200
+      )
+
+      expect(WebMock).to have_requested(:post, "https://self-hosted.example.com/api/v2/llm_request_logs")
+      expect(WebMock).not_to have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+    end
   end
 
   describe "debug_mode with send_llm_request_log" do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -103,6 +103,92 @@ RSpec.describe Coolhand do
     end
   end
 
+  describe "base_url config" do
+    it "defaults to https://coolhandlabs.com/api" do
+      expect(config.base_url).to eq("https://coolhandlabs.com/api")
+    end
+
+    it "accepts a custom https:// URL" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "https://self-hosted.example.com/api"
+      end
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+
+    it "accepts http://localhost for local dev" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://localhost:3000/api"
+      end
+      expect(config.base_url).to eq("http://localhost:3000/api")
+    end
+
+    it "accepts http://127.0.0.1 for local dev" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://127.0.0.1:3000/api"
+      end
+      expect(config.base_url).to eq("http://127.0.0.1:3000/api")
+    end
+
+    it "raises an error for non-https, non-localhost URLs" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = "http://example.com/api"
+        end
+      end.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises an error for http://localhost-prefixed hostnames (security: exact host match)" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = "http://localhost.attacker.com/api"
+        end
+      end.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises an error for http://127.0.0.1-prefixed hostnames (security: exact host match)" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = "http://127.0.0.1.evil.com/api"
+        end
+      end.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises an error when base_url is set to nil" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = nil
+        end
+      end.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "strips trailing slashes" do
+      config.base_url = "https://self-hosted.example.com/api/"
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+
+    it "strips multiple trailing slashes" do
+      config.base_url = "https://self-hosted.example.com/api///"
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+  end
+
   describe ".without_capture" do
     it "sets thread-local override to false within the block" do
       Coolhand.without_capture do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -186,6 +186,49 @@ RSpec.describe Coolhand do
       config.base_url = "https://self-hosted.example.com/api///"
       expect(config.base_url).to eq("https://self-hosted.example.com/api")
     end
+
+    it "accepts mixed-case localhost (case-insensitive host match)" do
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://LOCALHOST:3000/api"
+      end
+      expect(config.base_url).to eq("http://LOCALHOST:3000/api")
+    end
+
+    it "accepts http://[::1] IPv6 loopback for local dev" do
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://[::1]:3000/api"
+      end
+      expect(config.base_url).to eq("http://[::1]:3000/api")
+    end
+
+    it "raises for https:// with no host" do
+      expect { config.base_url = "https://" }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises for https: with nil host" do
+      expect { config.base_url = "https:" }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises for an empty string" do
+      expect { config.base_url = "" }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises for a malformed URL (locks in URI::InvalidURIError rescue)" do
+      expect { config.base_url = "http://[bad" }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises for http://0.0.0.0 (loopback-looking but not a valid local-dev host)" do
+      expect { config.base_url = "http://0.0.0.0/api" }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "raises immediately on direct setter assignment without configure (eager validation)" do
+      expect { Coolhand.configuration.base_url = "http://evil.com/api" }
+        .to raise_error(Coolhand::Error, /base_url must use https/)
+    end
   end
 
   describe ".without_capture" do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -104,12 +104,13 @@ RSpec.describe Coolhand do
   end
 
   describe "base_url config" do
+    before { allow(Coolhand::NetHttpInterceptor).to receive(:patch!) }
+
     it "defaults to https://coolhandlabs.com/api" do
       expect(config.base_url).to eq("https://coolhandlabs.com/api")
     end
 
     it "accepts a custom https:// URL" do
-      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
       Coolhand.configure do |c|
         c.api_key = "test-key"
         c.silent = true
@@ -119,7 +120,6 @@ RSpec.describe Coolhand do
     end
 
     it "accepts http://localhost for local dev" do
-      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
       Coolhand.configure do |c|
         c.api_key = "test-key"
         c.silent = true
@@ -129,7 +129,6 @@ RSpec.describe Coolhand do
     end
 
     it "accepts http://127.0.0.1 for local dev" do
-      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
       Coolhand.configure do |c|
         c.api_key = "test-key"
         c.silent = true

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe Coolhand::FeedbackService do
     it "configures with production endpoint" do
       expect(service.api_endpoint).to eq("https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
     end
+
+    it "uses configuration.base_url for its endpoint" do
+      custom_config = instance_double(Coolhand::Configuration,
+        api_key: "test-api-key",
+        base_url: "https://self-hosted.example.com/api",
+        silent: true,
+        environment: "production",
+        debug_mode: false)
+      allow(Coolhand).to receive(:configuration).and_return(custom_config)
+      expect(described_class.new.api_endpoint).to eq(
+        "https://self-hosted.example.com/api/v2/llm_request_log_feedbacks"
+      )
+    end
   end
 
   describe "#create_feedback" do


### PR DESCRIPTION
## What's new

- `config.base_url` is now a validated, documented configuration option. Set it to any `https://` URL to redirect all log and feedback POSTs to a self-hosted backend instead of `https://coolhandlabs.com/api`.
- `http://localhost` and `http://127.0.0.1` are accepted as an explicit opt-in for local development.
- Trailing slashes are stripped at assignment time so the `/v2/` path is always appended cleanly.

## What changed

- `Configuration#base_url` is now an `attr_reader` with a custom setter (was a plain `attr_accessor`). The setter uses `URI.parse` for host validation — exact host comparison prevents prefix-match bypass (e.g. `http://localhost.attacker.com` is correctly rejected). `nil` base_url now fails at configure time rather than silently producing a broken endpoint at request time.
- `validate!` raises `Coolhand::Error` if `base_url` is not `https://` or an explicit localhost value.
- README: new **Self-Hosted Deployments** section with example configuration.
- CHANGELOG: new feature and breaking change entries under `[Unreleased]`.
- 11 new specs covering accepted schemes, rejection cases, security edge cases, and trailing-slash normalisation.

## Breaking changes

`Coolhand.configure` now raises if `base_url` is set to a plain `http://` non-localhost URL. Previously any string was accepted silently. If you were pointing at an internal HTTP host (e.g. `http://logs.internal/api`), enable TLS on that host or front it with an `https://` proxy.

[closes #48]