### PR TITLE
Add base_url validation and trailing-slash normalization

### DIFF
--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -9,8 +9,8 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
-    attr_accessor :api_key, :environment, :silent, :base_url, :debug_mode, :capture, :exclude_api_patterns
-    attr_reader :intercept_addresses
+    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
+    attr_reader :intercept_addresses, :base_url
 
     def initialize
       # Set defaults
@@ -24,6 +24,10 @@ module Coolhand
       @debug_mode = false
       @capture = true
       @exclude_api_patterns = DEFAULT_EXCLUDE_API_PATTERNS.dup
+    end
+
+    def base_url=(value)
+      @base_url = value&.chomp("/")
     end
 
     # Custom setter that preserves defaults when nil/empty array is provided
@@ -45,6 +49,21 @@ module Coolhand
         Coolhand.log "❌ Coolhand Error: Intercept addresses cannot be empty. Please set it in the configuration."
         raise Error, "Intercept addresses cannot be empty"
       end
+
+      validate_base_url!
+    end
+
+    private
+
+    # Allows https:// for any host, and http:// only for loopback (localhost / 127.0.0.1).
+    # Other plain-http targets (0.0.0.0, host.docker.internal, remote hosts) are intentionally
+    # excluded — use a self-signed cert + https:// for those environments.
+    def validate_base_url!
+      return if base_url.nil?
+      return if base_url.start_with?("https://")
+      return if base_url.match?(%r{\Ahttp://(localhost|127\.0\.0\.1)(:\d+)?(/|\z)})
+
+      raise Error, "base_url must use https:// (http:// is only allowed for localhost / 127.0.0.1)"
     end
   end
 end

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe Coolhand::ApiService do
     end
   end
 
+  describe "custom base_url routing" do
+    before do
+      Coolhand.configuration.base_url = "https://my-server.example.com/api"
+      stub_request(:post, "https://my-server.example.com/api/v2/llm_request_logs")
+        .to_return(status: 200, body: JSON.generate({ id: 99 }),
+          headers: { "Content-Type" => "application/json" })
+    end
+
+    it "sends the request to the custom base_url" do
+      service = described_class.new
+      service.send_llm_request_log({ raw_request: { url: "https://api.openai.com" } })
+      expect(WebMock).to have_requested(:post, "https://my-server.example.com/api/v2/llm_request_logs")
+    end
+  end
+
   describe "debug_mode with create_feedback" do
     let(:service) { Coolhand::FeedbackService.new }
     let(:feedback) do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -209,6 +209,46 @@ RSpec.describe Coolhand do
     end
   end
 
+  describe "base_url config" do
+    it "defaults to https://coolhandlabs.com/api" do
+      expect(Coolhand::Configuration.new.base_url).to eq("https://coolhandlabs.com/api")
+    end
+
+    it "accepts a custom https URL" do
+      config.base_url = "https://my-server.example.com/api"
+      expect(config.base_url).to eq("https://my-server.example.com/api")
+    end
+
+    it "strips trailing slash on assignment" do
+      config.base_url = "https://my-server.example.com/api/"
+      expect(config.base_url).to eq("https://my-server.example.com/api")
+    end
+
+    it "raises on http:// non-localhost URL" do
+      config.api_key = "key"
+      config.base_url = "http://remote.example.com/api"
+      expect { config.validate! }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+
+    it "allows http://localhost" do
+      config.api_key = "key"
+      config.base_url = "http://localhost:3000/api"
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "allows http://127.0.0.1" do
+      config.api_key = "key"
+      config.base_url = "http://127.0.0.1:3000/api"
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "rejects http://0.0.0.0" do
+      config.api_key = "key"
+      config.base_url = "http://0.0.0.0:3000/api"
+      expect { config.validate! }.to raise_error(Coolhand::Error, /base_url must use https/)
+    end
+  end
+
   describe ".required_field?" do
     it "returns true for valid values" do
       expect(Coolhand.required_field?("valid")).to be true


### PR DESCRIPTION
## What's new

- `config.base_url` now normalizes trailing slashes on assignment, so `"https://example.com/api/"` and `"https://example.com/api"` are equivalent.
- Scheme validation is enforced at `Coolhand.configure` time: only `https://` URLs are accepted, with `http://` permitted for `localhost` and `127.0.0.1` (local development).

## Changed

- `base_url` is no longer a plain `attr_accessor` — it uses a custom setter for normalization and a private `validate_base_url!` called from `validate!`.

## Breaking changes

- Calling `Coolhand.configure` with a non-https `base_url` pointing at a remote host now raises `Coolhand::Error`. Plain-http loopback addresses (`localhost`, `127.0.0.1`) remain allowed.

[closes #48]