### PR TITLE
Add config.base_url validation for self-hosted deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 
+- **`config.base_url` validation for self-hosted deployments** — `base_url` now enforces `https://` by default; `http://localhost` and `http://127.0.0.1` are explicitly allowed for local development. Non-compliant schemes (e.g. plain `http://` to an external host) raise `Coolhand::Error` immediately at assignment. Trailing slashes are stripped automatically so appending the v2 path never produces double-slash URLs.
+
 ## [0.3.0] - 2026-03-01
 
 ### 🚀 Major Changes

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "uri"
 require "yaml"
 
 module Coolhand
@@ -9,8 +10,8 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
-    attr_accessor :api_key, :environment, :silent, :base_url, :debug_mode, :capture, :exclude_api_patterns
-    attr_reader :intercept_addresses
+    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
+    attr_reader :intercept_addresses, :base_url
 
     def initialize
       # Set defaults
@@ -31,6 +32,22 @@ module Coolhand
       return if value.nil? || (value.is_a?(Array) && value.empty?)
 
       @intercept_addresses = value.is_a?(Array) ? value : [value]
+    end
+
+    def base_url=(value)
+      return if value.nil?
+
+      normalized = value.to_s.sub(%r{/+\z}, "")
+      uri = URI.parse(normalized)
+
+      allowed = uri.scheme == "https" ||
+                (uri.scheme == "http" && ["localhost", "127.0.0.1"].include?(uri.host))
+
+      raise Error, "base_url must use https:// (use http://localhost or http://127.0.0.1 for local dev)" unless allowed
+
+      @base_url = normalized
+    rescue URI::InvalidURIError
+      raise Error, "base_url is not a valid URL: #{value.inspect}"
     end
 
     def validate!

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe Coolhand::ApiService do
     end
   end
 
+  describe "custom base_url" do
+    let(:service) { described_class.new }
+
+    before do
+      Coolhand.configuration.base_url = "https://self-hosted.example.com/api"
+      stub_request(:post, "https://self-hosted.example.com/api/v2/llm_request_logs")
+        .to_return(status: 200, body: JSON.generate({ id: 1 }), headers: { "Content-Type" => "application/json" })
+    end
+
+    it "posts to the configured base_url" do
+      service.send_llm_request_log({ raw_request: {} })
+      expect(WebMock).to have_requested(:post, "https://self-hosted.example.com/api/v2/llm_request_logs")
+    end
+  end
+
   describe "debug_mode with send_llm_request_log" do
     let(:service) { described_class.new }
     let(:request_data) do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -92,6 +92,52 @@ RSpec.describe Coolhand do
     end
   end
 
+  describe "base_url config" do
+    it "defaults to https://coolhandlabs.com/api" do
+      expect(config.base_url).to eq("https://coolhandlabs.com/api")
+    end
+
+    it "accepts a valid https URL" do
+      config.base_url = "https://self-hosted.example.com/api"
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+
+    it "strips a trailing slash" do
+      config.base_url = "https://self-hosted.example.com/api/"
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+
+    it "strips multiple trailing slashes" do
+      config.base_url = "https://self-hosted.example.com/api///"
+      expect(config.base_url).to eq("https://self-hosted.example.com/api")
+    end
+
+    it "allows http://localhost for local development" do
+      config.base_url = "http://localhost:3000/api"
+      expect(config.base_url).to eq("http://localhost:3000/api")
+    end
+
+    it "allows http://127.0.0.1 for local development" do
+      config.base_url = "http://127.0.0.1:3000/api"
+      expect(config.base_url).to eq("http://127.0.0.1:3000/api")
+    end
+
+    it "rejects a plain http:// external URL" do
+      expect { config.base_url = "http://self-hosted.example.com/api" }
+        .to raise_error(Coolhand::Error, /https/)
+    end
+
+    it "rejects an invalid URL string" do
+      expect { config.base_url = "not a url" }
+        .to raise_error(Coolhand::Error)
+    end
+
+    it "preserves the default when set to nil" do
+      config.base_url = nil
+      expect(config.base_url).to eq("https://coolhandlabs.com/api")
+    end
+  end
+
   describe "capture config" do
     it "defaults to true" do
       expect(config.capture).to be true


### PR DESCRIPTION
Adds strict validation to `config.base_url` so the SDK can safely target self-hosted Coolhand endpoints.

**What's new:** `base_url=` now enforces `https://` by default. `http://localhost` and `http://127.0.0.1` are explicitly permitted as a local-dev opt-in. Trailing slashes are stripped automatically before the v2 path is appended, preventing double-slash URLs. Invalid schemes or malformed URLs raise `Coolhand::Error` immediately at assignment time (not deferred until the request fires).

**Nothing changes** for users who don't set `base_url` — the default (`https://coolhandlabs.com/api`) is unaffected and no existing configuration blocks need updating.

**Potentially breaking:** Any code that currently sets `base_url` to a plain `http://` external URL will now raise at configure time.

[closes #48]