### PR TITLE
Add config.base_url for self-hosted deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### ✨ New Features
+- **Configurable `base_url`** - `config.base_url` now accepts any `https://` URL to redirect log and feedback POSTs to a self-hosted endpoint. Defaults to `https://coolhandlabs.com/api` (behavior unchanged when unset). Trailing slashes are stripped automatically.
+
+### 💔 Breaking Changes
+- **`base_url` scheme validation** - `Coolhand.configure` now raises `Coolhand::Error` if `base_url` is set to a non-`https://` URL that is not a recognized loopback address (`localhost`, `127.0.0.1`, `::1`). Previously any URL was accepted silently. **Upgraders on internal `http://` endpoints** must either switch to `https://` or use a loopback address for local development.
 
 ## [0.3.0] - 2026-03-01
 

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "uri"
 require "yaml"
 
 module Coolhand
@@ -9,8 +10,8 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
-    attr_accessor :api_key, :environment, :silent, :base_url, :debug_mode, :capture, :exclude_api_patterns
-    attr_reader :intercept_addresses
+    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
+    attr_reader :intercept_addresses, :base_url
 
     def initialize
       # Set defaults
@@ -33,6 +34,10 @@ module Coolhand
       @intercept_addresses = value.is_a?(Array) ? value : [value]
     end
 
+    def base_url=(value)
+      @base_url = value.to_s.gsub(/\/+\z/, "")
+    end
+
     def validate!
       # Validate API Key after configuration
       if api_key.nil?
@@ -45,6 +50,33 @@ module Coolhand
         Coolhand.log "❌ Coolhand Error: Intercept addresses cannot be empty. Please set it in the configuration."
         raise Error, "Intercept addresses cannot be empty"
       end
+
+      validate_base_url!
+    end
+
+    private
+
+    LOCAL_HOSTS = %w[localhost 127.0.0.1 [::1]].freeze
+
+    def validate_base_url!
+      url = base_url.to_s
+      return if url.start_with?("https://")
+
+      if url.start_with?("http://")
+        host = begin
+          URI.parse(url).host.to_s.downcase
+        rescue URI::InvalidURIError
+          Coolhand.log "❌ Coolhand Error: base_url is not a valid URL. Got: #{url}"
+          raise Error, "base_url is not a valid URL"
+        end
+        return if LOCAL_HOSTS.include?(host)
+
+        Coolhand.log "❌ Coolhand Error: base_url must use https:// for non-local hosts. Got: #{url}"
+        raise Error, "base_url must use https:// for non-local hosts"
+      end
+
+      Coolhand.log "❌ Coolhand Error: base_url has an invalid scheme. Got: #{url}"
+      raise Error, "base_url has an invalid scheme"
     end
   end
 end

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -35,7 +35,7 @@ module Coolhand
     end
 
     def base_url=(value)
-      @base_url = value.to_s.gsub(/\/+\z/, "")
+      @base_url = value.to_s.gsub(%r{/+\z}, "")
     end
 
     def validate!
@@ -54,9 +54,9 @@ module Coolhand
       validate_base_url!
     end
 
-    private
-
     LOCAL_HOSTS = %w[localhost 127.0.0.1 [::1]].freeze
+
+    private
 
     def validate_base_url!
       url = base_url.to_s

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -127,4 +127,35 @@ RSpec.describe Coolhand::ApiService do
       end
     end
   end
+
+  describe "custom base_url routing" do
+    let(:custom_base) { "https://my-self-hosted.example.com/api" }
+    let(:request_data) do
+      {
+        method: "POST",
+        url: "https://api.openai.com/v1/chat/completions",
+        request_body: { model: "gpt-4" },
+        response_body: { choices: [] },
+        status_code: 200
+      }
+    end
+
+    before do
+      Coolhand.configuration.base_url = custom_base
+      stub_request(:post, "#{custom_base}/v2/llm_request_logs")
+        .to_return(status: 200, body: JSON.generate({ id: 99 }), headers: { "Content-Type" => "application/json" })
+    end
+
+    it "sends requests to the custom base_url" do
+      service = described_class.new
+      service.send_llm_request_log(request_data)
+      expect(WebMock).to have_requested(:post, "#{custom_base}/v2/llm_request_logs")
+    end
+
+    it "does not send requests to the default base_url" do
+      service = described_class.new
+      service.send_llm_request_log(request_data)
+      expect(WebMock).not_to have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+    end
+  end
 end

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -103,6 +103,103 @@ RSpec.describe Coolhand do
     end
   end
 
+  describe "base_url config" do
+    it "defaults to https://coolhandlabs.com/api" do
+      fresh_config = Coolhand::Configuration.new
+      expect(fresh_config.base_url).to eq("https://coolhandlabs.com/api")
+    end
+
+    it "accepts a custom https URL" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "https://my-self-hosted.example.com/api"
+      end
+      expect(Coolhand.configuration.base_url).to eq("https://my-self-hosted.example.com/api")
+    end
+
+    it "strips a single trailing slash from base_url" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "https://my-self-hosted.example.com/api/"
+      end
+      expect(Coolhand.configuration.base_url).to eq("https://my-self-hosted.example.com/api")
+    end
+
+    it "strips multiple trailing slashes from base_url" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "https://my-self-hosted.example.com/api//"
+      end
+      expect(Coolhand.configuration.base_url).to eq("https://my-self-hosted.example.com/api")
+    end
+
+    it "rejects a non-local http:// URL" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = "http://my-self-hosted.example.com/api"
+        end
+      end.to raise_error(Coolhand::Error, /base_url must use https:\/\//)
+    end
+
+    it "allows http://localhost for local development" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://localhost:3000/api"
+      end
+      expect(Coolhand.configuration.base_url).to eq("http://localhost:3000/api")
+    end
+
+    it "allows http://127.0.0.1 for local development" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://127.0.0.1:3000/api"
+      end
+      expect(Coolhand.configuration.base_url).to eq("http://127.0.0.1:3000/api")
+    end
+
+    it "allows http://::1 (IPv6 loopback) for local development" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://[::1]:3000/api"
+      end
+      expect(Coolhand.configuration.base_url).to eq("http://[::1]:3000/api")
+    end
+
+    it "allows http://LOCALHOST with mixed case" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
+      Coolhand.configure do |c|
+        c.api_key = "test-key"
+        c.silent = true
+        c.base_url = "http://LOCALHOST:3000/api"
+      end
+      expect(Coolhand.configuration.base_url).to eq("http://LOCALHOST:3000/api")
+    end
+
+    it "rejects a malformed http:// URL" do
+      expect do
+        Coolhand.configure do |c|
+          c.api_key = "test-key"
+          c.silent = true
+          c.base_url = "http://[bad"
+        end
+      end.to raise_error(Coolhand::Error, /base_url is not a valid URL/)
+    end
+  end
+
   describe ".without_capture" do
     it "sets thread-local override to false within the block" do
       Coolhand.without_capture do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Coolhand do
           c.silent = true
           c.base_url = "http://my-self-hosted.example.com/api"
         end
-      end.to raise_error(Coolhand::Error, /base_url must use https:\/\//)
+      end.to raise_error(Coolhand::Error, %r{base_url must use https://})
     end
 
     it "allows http://localhost for local development" do


### PR DESCRIPTION
## What's new

- `config.base_url` — set a custom API host to redirect log and feedback POSTs to a self-hosted endpoint. Defaults to `https://coolhandlabs.com/api`; behavior is unchanged when unset.
- Trailing slashes in `base_url` are stripped automatically.

## What changed

- `Configuration#base_url` is now an `attr_reader` backed by a custom setter (was a plain `attr_accessor`).
- `Coolhand.configure` now validates `base_url` scheme at configuration time.

## Breaking changes

- **`http://` URLs are rejected** unless the host is a loopback address (`localhost`, `127.0.0.1`, `[::1]`, case-insensitive). Any existing self-hosted setup using a plain `http://internal-host/api` URL will hit `Coolhand::Error` on `configure` — switch to `https://` or a loopback address.
- Malformed `http://` URLs now raise `Coolhand::Error` (was an unhandled `URI::InvalidURIError`).

[closes #48]