### PR TITLE
Add GitHub Models API endpoints to default intercept_addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### ✨ New Features
+- **GitHub Models API** - `models.github.ai` (current endpoint) and `models.inference.ai.azure.com` (deprecated endpoint) added to default `intercept_addresses`; calls routed through GitHub Copilot credentials are now captured automatically without manual configuration. Default intercept addresses are also now loaded from `default_intercept_addresses.yml` to make future additions a single-line YAML change.
 - **`config.base_url`** - Configurable API destination for self-hosted deployments. Defaults to `https://coolhandlabs.com/api`; set to any `https://` URL to redirect logs and feedback POSTs to your own backend. `http://localhost` and `http://127.0.0.1` are also accepted for local development. Trailing slashes are normalized automatically.
 
 ### 💔 Breaking Changes

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -10,6 +10,10 @@ module Coolhand
       File.join(__dir__, "default_exclude_api_patterns.yml")
     ).freeze
 
+    DEFAULT_INTERCEPT_ADDRESSES = YAML.load_file(
+      File.join(__dir__, "default_intercept_addresses.yml")
+    ).freeze
+
     BASE_URL_ERROR_MSG = "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
     LOOPBACK_HOSTS = %w[localhost 127.0.0.1 ::1].freeze
 
@@ -21,9 +25,7 @@ module Coolhand
       @environment = "production"
       @api_key = nil
       @silent = false
-      @intercept_addresses = ["api.openai.com", "api.anthropic.com", "api.elevenlabs.io",
-                              "generativelanguage.googleapis.com",
-                              ":generateContent", ":streamGenerateContent"]
+      @intercept_addresses = DEFAULT_INTERCEPT_ADDRESSES.dup
       self.base_url = "https://coolhandlabs.com/api"
       @debug_mode = false
       @capture = true

--- a/lib/coolhand/default_intercept_addresses.yml
+++ b/lib/coolhand/default_intercept_addresses.yml
@@ -1,0 +1,15 @@
+# Coolhand default intercept addresses
+# These substrings are matched against request URLs to decide whether a request
+# should be captured and forwarded as an llm_request_log.
+#
+# Users can extend defaults:   c.intercept_addresses << "my.custom.api.com"
+# Users can override entirely: c.intercept_addresses = ["only.this.com"]
+
+- "api.openai.com"
+- "api.anthropic.com"
+- "api.elevenlabs.io"
+- "generativelanguage.googleapis.com"
+- "models.github.ai"
+- "models.inference.ai.azure.com"
+- ":generateContent"
+- ":streamGenerateContent"

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -38,12 +38,7 @@ RSpec.describe Coolhand do
         end
       end.not_to raise_error
 
-      expect(Coolhand.configuration.intercept_addresses).to eq(["api.openai.com",
-                                                                "api.anthropic.com",
-                                                                "api.elevenlabs.io",
-                                                                "generativelanguage.googleapis.com",
-                                                                ":generateContent",
-                                                                ":streamGenerateContent"])
+      expect(Coolhand.configuration.intercept_addresses).to eq(Coolhand::Configuration::DEFAULT_INTERCEPT_ADDRESSES)
     end
 
     it "calls Interceptor.patch!" do
@@ -55,12 +50,7 @@ RSpec.describe Coolhand do
         c.intercept_addresses = []
       end
 
-      expect(Coolhand.configuration.intercept_addresses).to eq(["api.openai.com",
-                                                                "api.anthropic.com",
-                                                                "api.elevenlabs.io",
-                                                                "generativelanguage.googleapis.com",
-                                                                ":generateContent",
-                                                                ":streamGenerateContent"])
+      expect(Coolhand.configuration.intercept_addresses).to eq(Coolhand::Configuration::DEFAULT_INTERCEPT_ADDRESSES)
     end
 
     it "allows custom intercept_addresses to be set" do


### PR DESCRIPTION
## What's new

- `models.github.ai` (current GitHub Models endpoint) and `models.inference.ai.azure.com` (deprecated Azure inference endpoint) are now included in the default `intercept_addresses`. GitHub Copilot-routed LLM calls are captured automatically without any manual configuration.
- Default intercept addresses are now loaded from `lib/coolhand/default_intercept_addresses.yml` instead of a hardcoded array in `Configuration#initialize`, matching the existing pattern for `default_exclude_api_patterns.yml`. A new `DEFAULT_INTERCEPT_ADDRESSES` constant is exposed on the class. Adding future providers is now a single-line YAML change with no Ruby or test edits required.

## Breaking changes

None.

[closes #46]