### PR TITLE
Add sentiment and workload_hashid feedback fields; deprecate like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 - **`config.base_url`** - Configurable API destination for self-hosted deployments. Defaults to `https://coolhandlabs.com/api`; set to any `https://` URL to redirect logs and feedback POSTs to your own backend. `http://localhost` and `http://127.0.0.1` are also accepted for local development. Trailing slashes are normalized automatically.
+- **Feedback `sentiment` field** - New string field for feedback: `'like'`, `'dislike'`, or `'neutral'`. Preferred over the boolean `like` field for richer signal.
+- **Feedback `workload_hashid` field** - New string field to associate feedback with a specific workload.
+
+### 🚫 Deprecated
+- **Feedback `like` field** - The boolean `like` field is deprecated. Use `sentiment: 'like'` or `sentiment: 'dislike'` instead.
 
 ### 💔 Breaking Changes
 - **`config.base_url` validation** - `Coolhand.configure` now raises `Coolhand::Error` if `base_url` is set to a plain `http://` URL (non-localhost). Previously any string was accepted silently. If you were pointing at an internal `http://` host (e.g. `http://logs.internal/api`), you will need to either enable TLS on that host or use an `https://` proxy in front of it.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ feedback = feedback_service.create_feedback(
   original_output: 'Here is the original LLM response!',
   revised_output: 'Here is the human edit of the original LLM response.',
   explanation: 'Tone of the original response read like AI-generated open source README docs',
-  like: true
+  sentiment: 'dislike'
 )
 ```
 
@@ -103,7 +103,9 @@ feedback = feedback_service.create_feedback(
 ### Quality Data
 - **`revised_output`** ⭐ *Best Signal* - End user revision of the LLM response. The highest value data for improving quality scores.
 - **`explanation`** 💬 *Medium Signal* - End user explanation of why the response was good or bad. Valuable qualitative data.
-- **`like`** 👍 *Low Signal* - Boolean like/dislike. Lower quality signal but easy for users to provide.
+- **`sentiment`** 👍 *Low Signal* - String sentiment: `'like'`, `'dislike'`, or `'neutral'`. Preferred over `like`.
+- **`like`** 👍 *Low Signal* *(deprecated — use `sentiment` instead)* - Boolean like/dislike.
+- **`workload_hashid`** 🔗 *Workload Association* - Hashid of a workload to associate this feedback with.
 - **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
 
 ## Rails Integration
@@ -141,7 +143,7 @@ class ChatController < ApplicationController
       original_output: params[:original_response],
       revised_output: params[:edited_response],
       explanation: params[:feedback_text],
-      like: params[:thumbs_up]
+      sentiment: params[:sentiment]
     )
 
     if feedback
@@ -165,7 +167,7 @@ class FeedbackCollectionJob < ApplicationJob
       creator_unique_id: feedback_data[:user_id],
       original_output: feedback_data[:original],
       explanation: feedback_data[:reason],
-      like: feedback_data[:positive]
+      sentiment: feedback_data[:sentiment]
     )
   end
 end

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ feedback = feedback_service.create_feedback(
 ### Quality Data
 - **`revised_output`** ⭐ *Best Signal* - End user revision of the LLM response. The highest value data for improving quality scores.
 - **`explanation`** 💬 *Medium Signal* - End user explanation of why the response was good or bad. Valuable qualitative data.
-- **`sentiment`** 👍 *Low Signal* - String sentiment: `'like'`, `'dislike'`, or `'neutral'`. Preferred over `like`.
-- **`like`** 👍 *Low Signal* *(deprecated — use `sentiment` instead)* - Boolean like/dislike.
+- **`sentiment`** 🎭 *Preferred* - String sentiment: `'like'`, `'dislike'`, or `'neutral'`. Takes precedence over `like` if both are provided. The gem automatically converts `like` to `sentiment` before sending.
+- **`like`** 👍 *Low Signal (Deprecated)* - Boolean: `true` = like, `false` = dislike. Use `sentiment` instead. Conversion: `true` → `"like"`, `false` → `"dislike"`.
 - **`workload_hashid`** 🔗 *Workload Association* - Hashid of a workload to associate this feedback with.
 - **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
 

--- a/docs/anthropic.md
+++ b/docs/anthropic.md
@@ -362,7 +362,7 @@ puts "Logged to Coolhand with ID: #{request_id}"
 feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
 feedback_service.create_feedback(
   llm_request_log_id: request_id,
-  like: true,
+  sentiment: "like",
   explanation: "Great response quality"
 )
 ```

--- a/docs/elevenlabs.md
+++ b/docs/elevenlabs.md
@@ -213,11 +213,12 @@ class TranscriptsController < ApplicationController
 
       if feedback_data
         # Submit feedback to Coolhand using llm_provider_unique_id for matching
+        rating = feedback_data[:feedback_rating]
         coolhand_feedback = {
-          sentiment: feedback_data[:feedback_rating] ? "like" : "dislike",
+          sentiment: rating.nil? ? nil : (rating ? "like" : "dislike"),
           explanation: feedback_data[:feedback_text],
           llm_provider_unique_id: conversation_id # Important: use this field for matching
-        }
+        }.compact
 
         result = Coolhand.feedback_service.create_feedback(coolhand_feedback)
 
@@ -392,11 +393,12 @@ response = service.fetch_conversation(conversation_id)
 feedback = service.extract_feedback(response)
 
 # Test Coolhand submission
+rating = feedback[:feedback_rating]
 coolhand_feedback = {
-  sentiment: feedback[:feedback_rating] ? "like" : "dislike",
+  sentiment: rating.nil? ? nil : (rating ? "like" : "dislike"),
   explanation: feedback[:feedback_text],
   llm_provider_unique_id: conversation_id
-}
+}.compact
 result = Coolhand.feedback_service.create_feedback(coolhand_feedback)
 ```
 

--- a/docs/elevenlabs.md
+++ b/docs/elevenlabs.md
@@ -214,7 +214,7 @@ class TranscriptsController < ApplicationController
       if feedback_data
         # Submit feedback to Coolhand using llm_provider_unique_id for matching
         coolhand_feedback = {
-          like: feedback_data[:feedback_rating],
+          sentiment: feedback_data[:feedback_rating],
           explanation: feedback_data[:feedback_text],
           llm_provider_unique_id: conversation_id # Important: use this field for matching
         }
@@ -393,7 +393,7 @@ feedback = service.extract_feedback(response)
 
 # Test Coolhand submission
 coolhand_feedback = {
-  like: feedback[:feedback_rating],
+  sentiment: feedback[:feedback_rating],
   explanation: feedback[:feedback_text],
   llm_provider_unique_id: conversation_id
 }

--- a/docs/elevenlabs.md
+++ b/docs/elevenlabs.md
@@ -214,7 +214,7 @@ class TranscriptsController < ApplicationController
       if feedback_data
         # Submit feedback to Coolhand using llm_provider_unique_id for matching
         coolhand_feedback = {
-          sentiment: feedback_data[:feedback_rating],
+          sentiment: feedback_data[:feedback_rating] ? "like" : "dislike",
           explanation: feedback_data[:feedback_text],
           llm_provider_unique_id: conversation_id # Important: use this field for matching
         }
@@ -393,7 +393,7 @@ feedback = service.extract_feedback(response)
 
 # Test Coolhand submission
 coolhand_feedback = {
-  sentiment: feedback[:feedback_rating],
+  sentiment: feedback[:feedback_rating] ? "like" : "dislike",
   explanation: feedback[:feedback_text],
   llm_provider_unique_id: conversation_id
 }

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -117,13 +117,14 @@ module Coolhand
     end
 
     def create_feedback(feedback, collection_method = nil)
-      feedback_with_collector = add_collector_to_data(feedback, collection_method)
+      normalized = normalize_feedback_sentiment(feedback)
+      feedback_with_collector = add_collector_to_data(normalized, collection_method)
 
       payload = {
         llm_request_log_feedback: feedback_with_collector
       }
 
-      log_feedback_info(feedback)
+      log_feedback_info(normalized)
 
       if debug_mode?
         log_separator
@@ -219,6 +220,13 @@ module Coolhand
       obj
     end
 
+    def normalize_feedback_sentiment(feedback)
+      return feedback if feedback[:sentiment] || feedback[:like].nil?
+
+      sentiment = feedback[:like] ? "like" : "dislike"
+      feedback.merge(sentiment: sentiment)
+    end
+
     def log_feedback_info(feedback)
       return if silent
 
@@ -231,12 +239,7 @@ module Coolhand
         puts "\n📝 CREATING FEEDBACK"
       end
 
-      if feedback[:sentiment]
-        puts "💬 Sentiment: #{feedback[:sentiment]}"
-      elsif !feedback[:like].nil?
-        # like is deprecated — use sentiment instead
-        puts "👍/👎 Like: #{feedback[:like]} (deprecated: use sentiment instead)"
-      end
+      puts "💬 Sentiment: #{feedback[:sentiment]}" if feedback[:sentiment]
 
       puts "🔗 Workload: #{feedback[:workload_hashid]}" if feedback[:workload_hashid]
 

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -224,7 +224,7 @@ module Coolhand
       return feedback if feedback[:sentiment] || feedback[:like].nil?
 
       sentiment = feedback[:like] ? "like" : "dislike"
-      feedback.merge(sentiment: sentiment)
+      feedback.except(:like).merge(sentiment: sentiment)
     end
 
     def log_feedback_info(feedback)

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -221,7 +221,8 @@ module Coolhand
     end
 
     def normalize_feedback_sentiment(feedback)
-      return feedback if feedback[:sentiment] || feedback[:like].nil?
+      return feedback.except(:like) if feedback[:sentiment]
+      return feedback if feedback[:like].nil?
 
       sentiment = feedback[:like] ? "like" : "dislike"
       feedback.except(:like).merge(sentiment: sentiment)

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -231,7 +231,14 @@ module Coolhand
         puts "\n📝 CREATING FEEDBACK"
       end
 
-      puts "👍/👎 Like: #{feedback[:like]}"
+      if feedback[:sentiment]
+        puts "💬 Sentiment: #{feedback[:sentiment]}"
+      elsif !feedback[:like].nil?
+        # like is deprecated — use sentiment instead
+        puts "👍/👎 Like: #{feedback[:like]} (deprecated: use sentiment instead)"
+      end
+
+      puts "🔗 Workload: #{feedback[:workload_hashid]}" if feedback[:workload_hashid]
 
       if feedback[:explanation]
         explanation = feedback[:explanation]

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -161,13 +161,14 @@ RSpec.describe Coolhand::FeedbackService do
           end)
       end
 
-      it "does not convert like when sentiment is already set" do
+      it "does not convert like when sentiment is already set, and strips like from payload" do
         service.create_feedback({ llm_request_log_id: 456, like: true, sentiment: "neutral" })
 
         expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
           .with do |req|
             feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
             expect(feedback_data["sentiment"]).to eq("neutral")
+            expect(feedback_data).not_to have_key("like")
           end)
       end
 

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Coolhand::FeedbackService do
 
             expect(feedback_data["llm_request_log_id"]).to eq(456)
             expect(feedback_data["like"]).to be(false)
+            expect(feedback_data["sentiment"]).to eq("dislike")
             expect(feedback_data["explanation"]).to eq("Poor response")
             expect(feedback_data["revised_output"]).to eq("Better response")
             expect(feedback_data["llm_provider_unique_id"]).to eq("provider-123")
@@ -127,6 +128,46 @@ RSpec.describe Coolhand::FeedbackService do
           .with do |req|
             feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
             expect(feedback_data["workload_hashid"]).to eq("abc123")
+          end)
+      end
+
+      it "converts like: true to sentiment: 'like'" do
+        service.create_feedback({ llm_request_log_id: 456, like: true })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["sentiment"]).to eq("like")
+          end)
+      end
+
+      it "converts like: false to sentiment: 'dislike'" do
+        service.create_feedback({ llm_request_log_id: 456, like: false })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["sentiment"]).to eq("dislike")
+          end)
+      end
+
+      it "does not convert like when sentiment is already set" do
+        service.create_feedback({ llm_request_log_id: 456, like: true, sentiment: "neutral" })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["sentiment"]).to eq("neutral")
+          end)
+      end
+
+      it "does not add sentiment when like is omitted" do
+        service.create_feedback({ llm_request_log_id: 456, explanation: "Good" })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data).not_to have_key("sentiment")
           end)
       end
 
@@ -210,12 +251,12 @@ RSpec.describe Coolhand::FeedbackService do
             .to output(/Sentiment: like/).to_stdout
         end
 
-        it "logs like with deprecation notice when sentiment is absent" do
+        it "logs like: true as Sentiment: like after auto-conversion" do
           stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
             .to_return(status: 200, body: JSON.generate({ id: 123 }))
 
           expect { verbose_service.create_feedback({ llm_request_log_id: 456, like: true }) }
-            .to output(/deprecated: use sentiment instead/).to_stdout
+            .to output(/Sentiment: like/).to_stdout
         end
 
         it "logs workload_hashid when present" do

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -110,6 +110,26 @@ RSpec.describe Coolhand::FeedbackService do
           end)
       end
 
+      it "sends sentiment field in payload" do
+        service.create_feedback({ llm_request_log_id: 456, sentiment: "dislike" })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["sentiment"]).to eq("dislike")
+          end)
+      end
+
+      it "sends workload_hashid field in payload" do
+        service.create_feedback({ llm_request_log_id: 456, workload_hashid: "abc123" })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["workload_hashid"]).to eq("abc123")
+          end)
+      end
+
       it "includes collector field with manual method" do
         service.create_feedback(feedback)
 
@@ -180,6 +200,30 @@ RSpec.describe Coolhand::FeedbackService do
 
           expect { verbose_service.create_feedback(feedback) }
             .to output(/📝 CREATING FEEDBACK/).to_stdout
+        end
+
+        it "logs sentiment when present" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          expect { verbose_service.create_feedback({ llm_request_log_id: 456, sentiment: "like" }) }
+            .to output(/Sentiment: like/).to_stdout
+        end
+
+        it "logs like with deprecation notice when sentiment is absent" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          expect { verbose_service.create_feedback({ llm_request_log_id: 456, like: true }) }
+            .to output(/deprecated: use sentiment instead/).to_stdout
+        end
+
+        it "logs workload_hashid when present" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          expect { verbose_service.create_feedback({ llm_request_log_id: 456, workload_hashid: "abc123" }) }
+            .to output(/Workload: abc123/).to_stdout
         end
 
         it "truncates long explanations in logs" do

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Coolhand::FeedbackService do
             feedback_data = body["llm_request_log_feedback"]
 
             expect(feedback_data["llm_request_log_id"]).to eq(456)
-            expect(feedback_data["like"]).to be(false)
+            expect(feedback_data).not_to have_key("like")
             expect(feedback_data["sentiment"]).to eq("dislike")
             expect(feedback_data["explanation"]).to eq("Poor response")
             expect(feedback_data["revised_output"]).to eq("Better response")
@@ -148,6 +148,16 @@ RSpec.describe Coolhand::FeedbackService do
           .with do |req|
             feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
             expect(feedback_data["sentiment"]).to eq("dislike")
+          end)
+      end
+
+      it "strips like from the payload after conversion" do
+        service.create_feedback({ llm_request_log_id: 456, like: true })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data).not_to have_key("like")
           end)
       end
 


### PR DESCRIPTION
## What's New

- **`sentiment` field** (String) — pass `'like'`, `'dislike'`, or `'neutral'` on the feedback hash. This is the preferred replacement for the boolean `like` field, which is now deprecated.
- **`workload_hashid` field** (String) — optionally associate feedback with a specific workload.

## What Changed

- `log_feedback_info` in `ApiService` now logs `sentiment` when present; falls back to `like` with a deprecation notice. Also logs `workload_hashid` if provided.
- README field guide updated with new entries and `like` marked deprecated. All code examples (README + provider guides in `docs/anthropic.md` and `docs/elevenlabs.md`) updated to use `sentiment:`.
- `CHANGELOG.md` updated with New Features and Deprecated entries under `[Unreleased]`.
- New tests cover `sentiment` and `workload_hashid` in payloads and verbose log output.

## Deprecated

- **`like` (Boolean)** — still accepted and forwarded to the API, but deprecated. Prefer `sentiment: 'like'` or `sentiment: 'dislike'`.