### PR TITLE
Clarify readiness log message

### DIFF
--- a/docs/anthropic.md
+++ b/docs/anthropic.md
@@ -380,7 +380,7 @@ Coolhand.configure do |config|
 end
 
 # Now you'll see console output like:
-# "✅ Coolhand ready - will log OpenAI and Anthropic (official gem) calls"
+# "✅ Coolhand ready - will log inference calls on monitored URIs"
 # "COOLHAND: ⚠️ Warning: Both 'anthropic' and 'ruby-anthropic' gems are installed..."
 ```
 

--- a/lib/coolhand.rb
+++ b/lib/coolhand.rb
@@ -49,7 +49,7 @@ module Coolhand
 
       NetHttpInterceptor.patch!
 
-      log "✅ Coolhand ready - will log OpenAI calls"
+      log "✅ Coolhand ready - will log inference calls on monitored URIs"
     end
 
     def capture


### PR DESCRIPTION
What changed: Coolhand now uses a provider-neutral readiness log message for monitored inference URIs instead of naming a single provider.
Docs: The Anthropic guide example has been updated to match the new startup output.
Breaking changes: None; this only changes console text when `silent` is false.

[closes #56]