### PR TITLE
Fix double-capture for bare Net::HTTP.new pattern

### DIFF
--- a/lib/coolhand/net_http_interceptor.rb
+++ b/lib/coolhand/net_http_interceptor.rb
@@ -41,18 +41,23 @@ module Coolhand
     def request(req, body = nil, &block)
       return super unless NetHttpInterceptor.patched?
 
+      active = (Thread.current[:coolhand_active_requests] ||= {}.compare_by_identity)
+      return super if active.key?(self)
+
       url = build_url_for_request(self, req)
       return super unless intercept?(url)
       return super unless should_capture?
 
+      # Capture body before setting the guard — if this raises we skip logging cleanly
+      # and the guard is never set, so there is no leak.
+      captured_body = capture_request_body(req, body)
+
+      active[self] = true
       start_time = Time.now
       request_id = SecureRandom.uuid
       response = nil
       status_code = nil
       response_body = nil
-
-      # Capture body before super — body_stream is consumed during send
-      captured_body = capture_request_body(req, body)
 
       Thread.current[:coolhand_stream_buffer] = nil
 
@@ -66,6 +71,7 @@ module Coolhand
         response_body = { "error" => { "class" => e.class.name, "message" => e.message } }
         raise
       ensure
+        active.delete(self)
         Thread.current[:coolhand_stream_buffer] = nil
         end_time = Time.now
         duration_ms = ((end_time - start_time) * 1000).round(2)

--- a/spec/coolhand/net_http_interceptor_spec.rb
+++ b/spec/coolhand/net_http_interceptor_spec.rb
@@ -48,6 +48,55 @@ RSpec.describe Coolhand::NetHttpInterceptor do
     expect(raw[:status_code] || raw["status_code"]).to eq(200)
   end
 
+  describe "re-entry guard" do
+    before(:each) do
+      stub_request(:get, "https://api.test.com/hello")
+        .to_return(status: 200, body: '{"msg":"hi"}', headers: { "Content-Type" => "application/json" })
+    end
+
+    it "logs exactly once with Net::HTTP.new(...).request(req) (bare new pattern)" do
+      uri = URI("https://api.test.com/hello")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = Net::HTTP::Get.new(uri)
+      http.request(req)
+      sleep 0.05
+
+      expect(api_service_instance).to have_received(:send_llm_request_log).once
+    end
+
+    it "logs exactly once with Net::HTTP.start(...) { |h| h.request(req) } pattern" do
+      uri = URI("https://api.test.com/hello")
+      req = Net::HTTP::Get.new(uri)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+      sleep 0.05
+
+      expect(api_service_instance).to have_received(:send_llm_request_log).once
+    end
+
+    it "logs independent requests made on a different connection inside a response callback" do
+      stub_request(:get, "https://api.test.com/second")
+        .to_return(status: 200, body: '{"msg":"second"}', headers: { "Content-Type" => "application/json" })
+
+      logs = []
+      allow(api_service_instance).to receive(:send_llm_request_log) { |arg| logs << arg }
+
+      uri1 = URI("https://api.test.com/hello")
+      req1 = Net::HTTP::Get.new(uri1)
+      Net::HTTP.start(uri1.host, uri1.port, use_ssl: true) do |http|
+        http.request(req1) do |_res|
+          uri2 = URI("https://api.test.com/second")
+          http2 = Net::HTTP.new(uri2.host, uri2.port)
+          http2.use_ssl = true
+          http2.request(Net::HTTP::Get.new(uri2))
+        end
+      end
+      sleep 0.05
+
+      expect(logs.size).to eq(2)
+    end
+  end
+
   it "captures streaming responses via read_body and marks is_streaming" do
     stub_request(:get, "https://api.test.com/stream")
       .to_return(status: 200, body: "chunk1chunk2", headers: { "Content-Type" => "application/octet-stream" })


### PR DESCRIPTION
[closes #57]

## What's new

`NetHttpInterceptor` now uses a `compare_by_identity` Hash (keyed by the `Net::HTTP` instance) as its re-entry guard instead of a boolean thread-local. This fixes double-logging when callers use `Net::HTTP.new(host, port).request(req)` without an explicit `start` block — Ruby's net/http internally wraps that call in `start { request(...) }`, which re-entered the prepended interceptor a second time.

## What changed

- Re-entry guard is now per-connection-object rather than per-thread, so independent requests made on a different `Net::HTTP` instance inside a response callback are still captured (previously suppressed).
- `capture_request_body` is now called before the guard is set, so a raise there leaves the thread in a clean state with no leaked flag.

## Breaking changes

None.