### PR TITLE
Fix UTF-8 handling for streaming responses

### DIFF
--- a/lib/coolhand/net_http_interceptor.rb
+++ b/lib/coolhand/net_http_interceptor.rb
@@ -59,6 +59,7 @@ module Coolhand
       begin
         response = super
         body_content = Thread.current[:coolhand_stream_buffer] || response&.body
+        body_content = body_content.dup.force_encoding("UTF-8") if body_content.is_a?(String)
         status_code = response.respond_to?(:code) ? response.code.to_i : nil
         response_body = parse_json(body_content)
       rescue StandardError => e

--- a/spec/coolhand/net_http_interceptor_spec.rb
+++ b/spec/coolhand/net_http_interceptor_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe Coolhand::NetHttpInterceptor do
     expect(resp_body).not_to be_nil
   end
 
+  it "does not emit a JSON BINARY encoding warning when streaming multi-byte UTF-8 content" do
+    multibyte_body = "{\"text\":\"こんにちは世界\"}".b
+    stub_request(:post, "https://api.test.com/stream")
+      .to_return(status: 200, body: multibyte_body, headers: { "Content-Type" => "application/json" })
+
+    uri = URI("https://api.test.com/stream")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    req = Net::HTTP::Post.new(uri)
+    req.body = "{\"messages\":[]}"
+
+    chunks = []
+    expect do
+      http.request(req) do |res|
+        res.read_body { |chunk| chunks << chunk }
+      end
+      sleep 0.05
+    end.not_to output(/BINARY/).to_stderr
+  end
+
   describe "capture control" do
     before(:each) do
       stub_request(:get, "https://api.test.com/hello")


### PR DESCRIPTION
What's new: Net::HTTP response capture now treats streamed response content as UTF-8 before JSON parsing, preventing noisy BINARY encoding warnings for multi-byte JSON responses.
What changed: added a regression spec covering streamed multi-byte UTF-8 content through `read_body`.
Breaking changes: none expected; this preserves the public API and only changes captured response encoding before logging.

[closes #55]