### PR TITLE
Add Gem Version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coolhand Ruby Monitor
 
+[![Gem Version](https://badge.fury.io/rb/coolhand.svg)](https://badge.fury.io/rb/coolhand)
+
 Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, Cohere, and more) to the Coolhand analytics platform.
 
 ## Installation


### PR DESCRIPTION
Adds a Gem Version badge (via badge.fury.io) to the top of the README, making it easy to see the current published version of the `coolhand` gem at a glance.