### PR TITLE
Add openrouter.ai to default intercept addresses

### DIFF
--- a/lib/coolhand/default_intercept_addresses.yml
+++ b/lib/coolhand/default_intercept_addresses.yml
@@ -7,6 +7,7 @@
 
 - "api.openai.com"
 - "api.anthropic.com"
+- "openrouter.ai"
 - "api.elevenlabs.io"
 - "generativelanguage.googleapis.com"
 - "models.github.ai"


### PR DESCRIPTION
Adds `openrouter.ai` to the default list of intercepted URLs, similar to #64. The main Coolhand app now has an OpenRouter ingestor since OpenRouter uses an OpenAI-compatible API, so the Ruby SDK should intercept those calls automatically without requiring users to manually add it to their intercept addresses.