### PR TITLE
Add Vertex AI and Cloudflare AI Gateway to default intercept addresses

### DIFF
--- a/lib/coolhand/default_intercept_addresses.yml
+++ b/lib/coolhand/default_intercept_addresses.yml
@@ -13,3 +13,5 @@
 - "models.inference.ai.azure.com"
 - ":generateContent"
 - ":streamGenerateContent"
+- "aiplatform.googleapis.com"
+- "gateway.ai.cloudflare.com"

--- a/lib/coolhand/default_intercept_addresses.yml
+++ b/lib/coolhand/default_intercept_addresses.yml
@@ -15,3 +15,5 @@
 - ":streamGenerateContent"
 - "aiplatform.googleapis.com"
 - "gateway.ai.cloudflare.com"
+- "bedrock-runtime"
+- "openrouter.ai"


### PR DESCRIPTION
Adds missing provider endpoints to `default_intercept_addresses.yml`:

- `aiplatform.googleapis.com` — Vertex AI native calls and OpenAI-compatible `/chat/completions` endpoint (previously only `:generateContent`/`:streamGenerateContent` were matched)
- `gateway.ai.cloudflare.com` — Cloudflare AI Gateway (was entirely absent)
- `bedrock-runtime` — AWS Bedrock OpenAI-compatible endpoint; substring match covers all regions (e.g. `bedrock-runtime.us-east-1.amazonaws.com`)
- `openrouter.ai` — OpenRouter direct calls

No breaking changes.

[closes #64]