### PR TITLE
Add creator_type to feedback for API parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ feedback = feedback_service.create_feedback(
 - **`like`** 👍 *Low Signal (Deprecated)* - Boolean: `true` = like, `false` = dislike. Use `sentiment` instead. Conversion: `true` → `"like"`, `false` → `"dislike"`.
 - **`workload_hashid`** 🔗 *Workload Association* - Hashid of a workload to associate this feedback with.
 - **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
+- **`creator_type`** 🧑‍🤝‍🤖 *Creator Type* - What kind of creator submitted the feedback: `'human'`, `'agent'`, or `'unknown'`.
 
 ## Rails Integration
 

--- a/spec/coolhand/feedback_service_spec.rb
+++ b/spec/coolhand/feedback_service_spec.rb
@@ -131,6 +131,16 @@ RSpec.describe Coolhand::FeedbackService do
           end)
       end
 
+      it "sends creator_type field in payload" do
+        service.create_feedback({ llm_request_log_id: 456, creator_type: "agent" })
+
+        expect(WebMock).to(have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_log_feedbacks")
+          .with do |req|
+            feedback_data = JSON.parse(req.body)["llm_request_log_feedback"]
+            expect(feedback_data["creator_type"]).to eq("agent")
+          end)
+      end
+
       it "converts like: true to sentiment: 'like'" do
         service.create_feedback({ llm_request_log_id: 456, like: true })
 


### PR DESCRIPTION
Adds the `creator_type` feedback field (`human` / `agent` / `unknown`) to keep coolhand-ruby in parity with the now-deployed Coolhand API and the coolhand-node SDK, which already expose it.

The gem forwards the feedback hash to the API as-is, so `creator_type` already works at runtime - this PR documents it in the README and adds a spec verifying it is sent in the payload.