### PR TITLE
Add enabled flag and defer api_key validation to first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `Configuration#enabled` flag (default `true`). Set to `false` to skip all patching and validation, e.g. `config.enabled = Rails.env.production?`.
+
+### Changed
+- Missing `api_key` no longer raises at `configure` time. Intercepted requests are silently skipped (with a warning log) when the key is absent, so apps that boot without a key in CI or non-production environments no longer crash.
+
 ## [0.3.0] - 2026-05-14
 
 ### 🚀 Major Changes

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ end
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `api_key` | String | *required* | Your Coolhand API key for authentication |
+| `api_key` | String | `nil` | Your Coolhand API key. If absent, intercepted requests are skipped with a warning log rather than raising at boot time |
+| `enabled` | Boolean | `true` | Set to `false` to disable all patching and validation (e.g. `Rails.env.production?`) |
 | `silent` | Boolean | `false` | Whether to suppress console output |
 | `intercept_addresses` | Array | `["api.openai.com", "api.anthropic.com"]` | Array of API endpoint strings to monitor |
 

--- a/lib/coolhand.rb
+++ b/lib/coolhand.rb
@@ -45,6 +45,8 @@ module Coolhand
     def configure
       yield(configuration)
 
+      return unless configuration.enabled
+
       configuration.validate!
 
       NetHttpInterceptor.patch!
@@ -58,13 +60,15 @@ module Coolhand
         return
       end
 
+      return yield unless configuration.enabled
+
       patched = NetHttpInterceptor.patched?
-
       NetHttpInterceptor.patch!
-
-      yield
-    ensure
-      NetHttpInterceptor.unpatch! unless patched
+      begin
+        yield
+      ensure
+        NetHttpInterceptor.unpatch! unless patched
+      end
     end
 
     def without_capture

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -65,6 +65,8 @@ module Coolhand
     end
 
     def send_request(payload, success_message)
+      return nil if missing_api_key?
+
       uri = URI.parse(@api_endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = (uri.scheme == "https")
@@ -117,6 +119,8 @@ module Coolhand
     end
 
     def create_feedback(feedback, collection_method = nil)
+      return nil if !debug_mode? && missing_api_key?
+
       normalized = normalize_feedback_sentiment(feedback)
       feedback_with_collector = add_collector_to_data(normalized, collection_method)
 
@@ -144,6 +148,8 @@ module Coolhand
     end
 
     def create_log(captured_data, collection_method = nil)
+      return nil if !debug_mode? && missing_api_key?
+
       raw_request_with_collector = add_collector_to_data({ raw_request: captured_data }, collection_method)
 
       payload = {
@@ -192,6 +198,13 @@ module Coolhand
     }.freeze
 
     private
+
+    def missing_api_key?
+      return false if Coolhand.required_field?(api_key)
+
+      Coolhand.log "⚠️  Coolhand: API key is missing — skipping log for this request."
+      true
+    end
 
     # Get all filtered field names as a flat array
     def filtered_field_names

--- a/lib/coolhand/configuration.rb
+++ b/lib/coolhand/configuration.rb
@@ -17,7 +17,7 @@ module Coolhand
     BASE_URL_ERROR_MSG = "base_url must use https:// (or http://localhost / http://127.0.0.1 for local dev)"
     LOOPBACK_HOSTS = %w[localhost 127.0.0.1 ::1].freeze
 
-    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns
+    attr_accessor :api_key, :environment, :silent, :debug_mode, :capture, :exclude_api_patterns, :enabled
     attr_reader :intercept_addresses, :base_url
 
     def initialize
@@ -30,6 +30,7 @@ module Coolhand
       @debug_mode = false
       @capture = true
       @exclude_api_patterns = DEFAULT_EXCLUDE_API_PATTERNS.dup
+      @enabled = true
     end
 
     # Custom setter that preserves defaults when nil/empty array is provided
@@ -47,12 +48,6 @@ module Coolhand
     end
 
     def validate!
-      # Validate API Key after configuration
-      if api_key.nil?
-        Coolhand.log "❌ Coolhand Error: API Key is required. Please set it in the configuration."
-        raise Error, "API Key is required"
-      end
-
       # Validate intercept_addresses after configuration
       if intercept_addresses.nil? || intercept_addresses.empty?
         Coolhand.log "❌ Coolhand Error: Intercept addresses cannot be empty. Please set it in the configuration."

--- a/spec/coolhand/api_service_spec.rb
+++ b/spec/coolhand/api_service_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe Coolhand::ApiService do
     end
   end
 
+  describe "#send_llm_request_log with missing api_key" do
+    let(:service) { described_class.new }
+    let(:request_data) do
+      { method: "POST", url: "https://api.openai.com/v1/chat/completions",
+        request_body: {}, response_body: {}, status_code: 200 }
+    end
+
+    before { Coolhand.configuration.api_key = nil }
+
+    it "returns nil without sending an HTTP request" do
+      result = service.send_llm_request_log(request_data)
+      expect(result).to be_nil
+      expect(WebMock).not_to have_requested(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+    end
+
+    it "logs a warning via Coolhand.log (respects silent)" do
+      expect(Coolhand).to receive(:log).with(/API key is missing/)
+      service.send_llm_request_log(request_data)
+    end
+
+    it "produces no output when silent is true" do
+      Coolhand.configuration.silent = true
+      expect { service.send_llm_request_log(request_data) }.not_to output.to_stdout
+    end
+  end
+
   describe "debug_mode with send_llm_request_log" do
     let(:service) { described_class.new }
     let(:request_data) do

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -19,13 +19,37 @@ RSpec.describe Coolhand do
       expect(config.api_key).to eq("test-key")
     end
 
-    it "raises error if api_key is missing" do
+    it "does not raise when api_key is missing — validation is deferred to first use" do
+      expect(Coolhand::NetHttpInterceptor).to receive(:patch!)
       expect do
         Coolhand.configure do |c|
           c.silent = true
           c.api_key = nil
         end
-      end.to raise_error(Coolhand::Error, /API Key is required/)
+      end.not_to raise_error
+    end
+
+    context "when enabled is false" do
+      it "does not call validate! or patch! and does not raise even with nil api_key" do
+        expect(Coolhand::NetHttpInterceptor).not_to receive(:patch!)
+        expect do
+          Coolhand.configure do |c|
+            c.enabled = false
+            c.silent = true
+            c.api_key = nil
+          end
+        end.not_to raise_error
+      end
+
+      it "stores config settings even when disabled" do
+        Coolhand.configure do |c|
+          c.enabled = false
+          c.silent = true
+          c.environment = "staging"
+        end
+        expect(config.environment).to eq("staging")
+        expect(config.enabled).to be false
+      end
     end
 
     it "preserves default intercept_addresses when set to nil" do


### PR DESCRIPTION
## What's new

- **`Configuration#enabled`** (default `true`) — set `config.enabled = Rails.env.production?` to skip all patching and validation in non-production environments without wrapping the entire configure block in a conditional.

## What changed

- `api_key` is no longer validated at configure time. A missing key now logs a per-request warning and skips the send rather than raising at boot — so CI, rake tasks, and asset compilation no longer crash when no key is set. `silent: true` suppresses the warning entirely, making a missing key a complete no-op.
- All send paths (`send_request`, `create_log`, `create_feedback`) share a single `missing_api_key?` helper so the skip behaviour and message stay in one place.
- `Coolhand.capture` respects `enabled: false` — it passes the block through without patching `Net::HTTP`.

## Potentially breaking

- Calling `Coolhand.configure` without an `api_key` no longer raises `Coolhand::Error`. Apps relying on configure-time key validation to catch misconfiguration at boot will need to add their own check or set `enabled = true` and watch for the per-request warnings.