### PR TITLE
Release v0.4.0: changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-22
+
 ### Added
-- `Configuration#enabled` flag (default `true`). Set to `false` to skip all patching and validation, e.g. `config.enabled = Rails.env.production?`.
+- **More default intercept addresses** — Vertex AI (`aiplatform.googleapis.com`), Cloudflare AI Gateway (`gateway.ai.cloudflare.com`), AWS Bedrock OpenAI-compatible endpoint (`bedrock-runtime`), and OpenRouter (`openrouter.ai`) are now monitored out of the box with no configuration required (#66).
+- **`Configuration#enabled` flag** — Set `config.enabled = false` (e.g. `config.enabled = Rails.env.production?`) to skip all patching and validation globally without restructuring your configure block (#68).
+- **Feedback `creator_type` field** — Pass `creator_type: 'human'`, `'agent'`, or `'unknown'` when submitting feedback to identify who originated the feedback; matches the Coolhand API field (#67).
 
 ### Changed
-- Missing `api_key` no longer raises at `configure` time. Intercepted requests are silently skipped (with a warning log) when the key is absent, so apps that boot without a key in CI or non-production environments no longer crash.
+- **Deferred `api_key` validation** — A missing `api_key` no longer raises at `Coolhand.configure` time. Intercepted requests are silently skipped (with a warning log) when the key is absent, so apps that boot without a key in CI or non-production environments no longer crash (#68).
+
+### Dependencies
+- Bumped `faraday` from 2.14.1 to 2.14.2 (#63).
 
 ## [0.3.0] - 2026-05-14
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coolhand (0.3.0)
+    coolhand (0.4.0)
       base64 (~> 0.2)
 
 GEM

--- a/lib/coolhand/version.rb
+++ b/lib/coolhand/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coolhand
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Prepares the **v0.4.0** release: bumps `VERSION` to `0.4.0` (and the matching `Gemfile.lock` entry) and fills out the CHANGELOG with all five changes landed since v0.3.0.

## What's new
- **More default intercept addresses** — Vertex AI, Cloudflare AI Gateway, AWS Bedrock OpenAI-compatible endpoint, and OpenRouter are now monitored out of the box (#66).
- **`Configuration#enabled` flag** — Set `config.enabled = false` to skip all patching and validation globally (#68).
- **Feedback `creator_type` field** — Tag feedback as `'human'`, `'agent'`, or `'unknown'` for parity with the Coolhand API (#67).

## What changed
- **Deferred `api_key` validation** — A missing `api_key` no longer raises at `Coolhand.configure` time; intercepted requests are skipped with a warning instead, so key-less boots (CI, non-prod) no longer crash (#68).
- Bumped `faraday` from 2.14.1 to 2.14.2 (#63).

## Breaking changes
None. This is an additive minor release; the deferred `api_key` validation is strictly more lenient than before.