### PR TITLE
docs: align README structure and CLAUDE.md with cross-SDK philosophy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,16 @@ This ensures:
 - Gem loads cleanly regardless of what providers are installed
 - Apps using path gems (local development) don't break from missing optional dependencies
 - Users only need gems for providers they actually use
+
+## README and docs philosophy
+
+The README is a landing page — install, quick start, what it supports, where to go next. Keep it scannable. When in doubt, link rather than expand.
+
+**Three rules:**
+- **Config**: the basic `Coolhand.configure` snippet belongs in the README. Anything requiring more than one code block (self-hosted `base_url`, custom intercept addresses) goes in `docs/configuration.md`.
+- **Feedback**: the basic `create_feedback` snippet belongs in the README. The full field table, matching strategies, and sentiment conversion details go in `docs/feedback.md`.
+- **Integrations**: each integration gets its own `docs/<name>.md` file. The README links to them from the Documentation section.
+
+**Align with coolhand-node.** When adding a section that exists in the Node README, match its structure and tone. The two READMEs should feel like siblings.
+
+**Discoverability (SEO / AEO).** Write headings, the package description, and the supported-libraries list with search engines and AI agents in mind: use full provider/framework names (e.g. "OpenAI", "Anthropic", "Google Gemini", "Cohere") rather than abbreviations. The goal is that searches for "Ruby LLM monitoring", "Anthropic Ruby logging", or "OpenAI Ruby observability" surface this gem.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Collect feedback on LLM responses to improve model performance.
 require 'coolhand'
 
 # Create feedback for an LLM response
-feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
+feedback_service = Coolhand::FeedbackService.new
 
 feedback = feedback_service.create_feedback(
   llm_request_log_id: 123,
@@ -106,7 +106,7 @@ end
 ```ruby
 class ChatController < ApplicationController
   def create_feedback
-    feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
+    feedback_service = Coolhand::FeedbackService.new
 
     feedback = feedback_service.create_feedback(
       llm_request_log_id: params[:log_id],
@@ -131,7 +131,7 @@ end
 ```ruby
 class FeedbackCollectionJob < ApplicationJob
   def perform(feedback_data)
-    feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
+    feedback_service = Coolhand::FeedbackService.new
 
     feedback_service.create_feedback(
       llm_provider_unique_id: feedback_data[:request_id],

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/coolhand.svg)](https://badge.fury.io/rb/coolhand)
 
-Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, Cohere, and more) to the Coolhand analytics platform.
+Monitor and log LLM API calls — OpenAI, Anthropic, Google Gemini, Cohere, and any Faraday-based or Net::HTTP client — to the Coolhand analytics platform. Supports Ruby LLM monitoring, request logging, and feedback collection.
 
 ## Installation
 
@@ -51,24 +51,7 @@ end
 
 ## Self-Hosted Deployments
 
-For compliance, data-residency, or cost reasons you can run your own Coolhand-compatible endpoint and point the SDK at it via `config.base_url`:
-
-```ruby
-Coolhand.configure do |config|
-  config.api_key  = ENV['COOLHAND_API_KEY']
-  config.base_url = ENV['COOLHAND_BASE_URL']  # e.g. "https://coolhand.internal.example.com/api"
-end
-```
-
-When `base_url` is unset the SDK defaults to `https://coolhandlabs.com/api` and behaviour is unchanged.
-
-**Accepted values:**
-- Any `https://` URL — required for production use
-- `http://localhost` or `http://127.0.0.1` — accepted for local development only
-
-**Trailing slashes** are stripped automatically, so `"https://example.com/api/"` and `"https://example.com/api"` are equivalent.
-
-The SDK raises `Coolhand::Error` at configure time if `base_url` is set to a plain `http://` URL pointing at a non-localhost host.
+Point the SDK at your own Coolhand-compatible endpoint via `config.base_url` for compliance or data-residency requirements. See [Self-Hosted Deployments →](docs/configuration.md).
 
 ## Feedback API
 
@@ -94,22 +77,7 @@ feedback = feedback_service.create_feedback(
 )
 ```
 
-**Field Guide:** All fields are optional, but here's how to get the best results:
-
-### Matching Fields
-- **`llm_request_log_id`** 🎯 *Exact Match* - ID from the Coolhand API response when the original LLM request was logged. Provides exact matching.
-- **`llm_provider_unique_id`** 🎯 *Exact Match* - The x-request-id from the LLM API response (e.g., "req_xxxxxxx")
-- **`original_output`** 🔍 *Fuzzy Match* - The original LLM response text. Provides fuzzy matching but isn't 100% reliable.
-- **`client_unique_id`** 🔗 *Your Internal Matcher* - Connect to an identifier from your system for internal matching
-
-### Quality Data
-- **`revised_output`** ⭐ *Best Signal* - End user revision of the LLM response. The highest value data for improving quality scores.
-- **`explanation`** 💬 *Medium Signal* - End user explanation of why the response was good or bad. Valuable qualitative data.
-- **`sentiment`** 🎭 *Preferred* - String sentiment: `'like'`, `'dislike'`, or `'neutral'`. Takes precedence over `like` if both are provided. The gem automatically converts `like` to `sentiment` before sending.
-- **`like`** 👍 *Low Signal (Deprecated)* - Boolean: `true` = like, `false` = dislike. Use `sentiment` instead. Conversion: `true` → `"like"`, `false` → `"dislike"`.
-- **`workload_hashid`** 🔗 *Workload Association* - Hashid of a workload to associate this feedback with.
-- **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
-- **`creator_type`** 🧑‍🤝‍🤖 *Creator Type* - What kind of creator submitted the feedback: `'human'`, `'agent'`, or `'unknown'`.
+For a full field reference and matching strategy, see [Feedback API →](docs/feedback.md).
 
 ## Rails Integration
 
@@ -488,10 +456,12 @@ class Vertex::BatchCallbackProcessor < BaseService
 end
 ```
 
-## Integration Guides
+## Documentation
 
-- **[Anthropic Integration](docs/anthropic.md)** - Complete guide for both official and community Anthropic gems, including streaming, dual gem handling, and troubleshooting
-- **[ElevenLabs Integration](docs/elevenlabs.md)** - Complete guide for integrating ElevenLabs Conversational AI with webhook capture and feedback submission
+- **[Configuration](docs/configuration.md)** — Self-hosted deployments, base_url rules, custom intercept addresses
+- **[Feedback API](docs/feedback.md)** — Full field reference, matching strategies, sentiment values
+- **[Anthropic Integration](docs/anthropic.md)** — Official and community Anthropic Ruby gems, streaming, dual gem handling, and troubleshooting
+- **[ElevenLabs Integration](docs/elevenlabs.md)** — Webhook capture, feedback submission, and Rails integration
 
 ## Security
 
@@ -510,6 +480,10 @@ end
 - **Questions?** [Create an issue](https://github.com/Coolhand-Labs/coolhand-ruby/issues)
 - **Contribute?** [Submit a pull request](https://github.com/Coolhand-Labs/coolhand-ruby/pulls)
 - **Support?** Visit [coolhandlabs.com](https://coolhandlabs.com)
+
+## About Coolhand Labs
+
+Coolhand Labs builds LLM observability and feedback tooling so teams can monitor, understand, and improve their AI applications. Learn more at [coolhandlabs.com](https://coolhandlabs.com).
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,49 @@
+# Advanced Configuration
+
+## Self-Hosted Deployments
+
+For compliance, data-residency, or cost reasons you can run your own Coolhand-compatible endpoint and point the SDK at it via `config.base_url`:
+
+```ruby
+Coolhand.configure do |config|
+  config.api_key  = ENV['COOLHAND_API_KEY']
+  config.base_url = ENV['COOLHAND_BASE_URL']  # e.g. "https://coolhand.internal.example.com/api"
+end
+```
+
+Or set both via environment variables — useful for 12-factor deployments where configuration comes from the environment:
+
+```bash
+export COOLHAND_API_KEY=your-api-key
+export COOLHAND_BASE_URL=https://coolhand.internal.example.com/api
+```
+
+When `base_url` is unset the SDK defaults to `https://coolhandlabs.com/api` and behaviour is unchanged.
+
+**URL validation rules:**
+- Any `https://` URL — required for production use
+- `http://localhost` or `http://127.0.0.1` — accepted for local development only
+- Non-HTTPS remote URLs are rejected: the SDK raises `Coolhand::Error` at configure time if `base_url` is set to a plain `http://` URL pointing at a non-localhost host
+
+**Trailing slashes** are stripped automatically, so `"https://example.com/api/"` and `"https://example.com/api"` are equivalent.
+
+---
+
+## Custom Intercept Addresses
+
+By default Coolhand captures requests to a built-in list of LLM API hosts (OpenAI, Anthropic, Google Gemini, ElevenLabs, GitHub Models, and more). To capture a custom endpoint — an internal proxy, a self-hosted model server, or a third-party gateway — override `intercept_addresses`:
+
+```ruby
+Coolhand.configure do |config|
+  config.api_key = ENV['COOLHAND_API_KEY']
+  config.intercept_addresses = [
+    'my-llm-proxy.internal',
+    'api.openai.com',      # include the defaults you still want
+    'api.anthropic.com',
+  ]
+end
+```
+
+Setting `intercept_addresses` **replaces** the default list entirely, so include any default hosts you still need.
+
+The default list can be found in `Coolhand::Configuration::DEFAULT_INTERCEPT_ADDRESSES`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,13 +11,6 @@ Coolhand.configure do |config|
 end
 ```
 
-Or set both via environment variables — useful for 12-factor deployments where configuration comes from the environment:
-
-```bash
-export COOLHAND_API_KEY=your-api-key
-export COOLHAND_BASE_URL=https://coolhand.internal.example.com/api
-```
-
 When `base_url` is unset the SDK defaults to `https://coolhandlabs.com/api` and behaviour is unchanged.
 
 **URL validation rules:**

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -1,0 +1,79 @@
+# Feedback API
+
+Collect user feedback on LLM responses to improve your AI outputs. The Feedback API lets you capture sentiment ratings, explanations, and human-corrected outputs.
+
+> **Frontend widget:** For browser-based feedback collection, see [coolhand-js](https://github.com/Coolhand-Labs/coolhand-js) — a lightweight JavaScript widget that captures actionable user feedback on any AI output.
+
+## Basic Usage
+
+```ruby
+require 'coolhand'
+
+feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
+
+# Positive feedback linked by log ID (most reliable)
+feedback_service.create_feedback(
+  llm_request_log_id: 12345,
+  sentiment: 'like',
+  explanation: 'Clear and accurate answer.',
+)
+
+# Negative feedback with a human correction
+feedback_service.create_feedback(
+  original_output: 'The capital of France is London.',
+  sentiment: 'dislike',
+  revised_output: 'The capital of France is Paris.',
+  explanation: 'Factually wrong.',
+)
+```
+
+---
+
+## Field Reference
+
+All fields are optional. Use at least one **Matching Field** to link feedback to its originating LLM request.
+
+### Matching Fields
+
+These fields identify which LLM request the feedback refers to. Use the most specific one available.
+
+| Field | Match type | Description |
+|---|---|---|
+| `llm_request_log_id` | Exact | Coolhand log ID returned when the original request was logged. Most reliable. |
+| `llm_provider_unique_id` | Exact | The provider's own request ID (e.g. `x-request-id` from Anthropic or OpenAI). |
+| `client_unique_id` | Exact | Your own internal identifier for the request (e.g. a database row ID). |
+| `original_output` | Fuzzy | The raw text the LLM produced. Used for fuzzy matching when no ID is available — less reliable. |
+
+### Quality Signals
+
+| Field | Signal strength | Description |
+|---|---|---|
+| `revised_output` | ⭐ Best | The human-corrected version of the LLM output. Highest-value signal for quality improvement. |
+| `explanation` | Medium | Free-text reason the response was good or bad. |
+| `sentiment` | Low–Medium | `"like"`, `"dislike"`, or `"neutral"`. **Preferred** over the deprecated `like` boolean. |
+| `like` | Low (deprecated) | Boolean: `true` = like, `false` = dislike. Auto-converted to `sentiment` before submission. Use `sentiment` instead. |
+
+### Attribution Fields
+
+| Field | Description |
+|---|---|
+| `creator_unique_id` | ID of the user providing feedback (for per-user quality tracking). |
+| `creator_type` | Who submitted the feedback: `"human"`, `"agent"`, or `"unknown"`. |
+| `workload_hashid` | Associate feedback with a specific workload in the Coolhand dashboard. |
+
+---
+
+## Sentiment Values
+
+| Value | Meaning |
+|---|---|
+| `"like"` | The response was helpful / correct |
+| `"dislike"` | The response was unhelpful / wrong |
+| `"neutral"` | Neither good nor bad (e.g. factual but irrelevant) |
+
+The deprecated `like: bool` field is still accepted and automatically converted:
+
+| `like` (bool) | Equivalent `sentiment` |
+|---|---|
+| `true` | `"like"` |
+| `false` | `"dislike"` |

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -9,7 +9,7 @@ Collect user feedback on LLM responses to improve your AI outputs. The Feedback 
 ```ruby
 require 'coolhand'
 
-feedback_service = Coolhand::FeedbackService.new(Coolhand.configuration)
+feedback_service = Coolhand::FeedbackService.new
 
 # Positive feedback linked by log ID (most reliable)
 feedback_service.create_feedback(


### PR DESCRIPTION
[closes #71]

Brings coolhand-ruby's docs in line with the shared coolhand-node/python philosophy: the README becomes a scannable landing page and detailed reference material moves into dedicated `docs/` files.

## What's new
- `docs/configuration.md` — Self-Hosted Deployments (`base_url` rules and accepted values) plus a new **Custom Intercept Addresses** section documenting `intercept_addresses` and `Coolhand::Configuration::DEFAULT_INTERCEPT_ADDRESSES`.
- `docs/feedback.md` — full Feedback API field reference grouped into Matching Fields, Quality Signals, and Attribution, plus sentiment value tables.
- README: new **Documentation** and **About Coolhand Labs** sections.
- CLAUDE.md: a **README and docs philosophy** section codifying the three rules (config/feedback/integrations) and SEO/AEO discoverability guidance.

## What changed
- README is slimmed: the inline Self-Hosted Deployments detail and the full Feedback field guide are replaced with short summaries that link to the new docs.
- The one-line description now uses full provider names (OpenAI, Anthropic, Google Gemini, Cohere) for discoverability.

## Breaking changes
None — documentation only; no code, API, or interface changes.