### PR TITLE
security: OIDC RubyGems publishing and CI hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mikecarroll

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         ruby-version: ['3.1', '3.2', '3.3', '3.4']
@@ -23,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -52,7 +57,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.ruby-version == '3.3'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: coverage/
@@ -61,13 +66,15 @@ jobs:
   lint:
     name: Lint (RuboCop)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -75,16 +82,21 @@ jobs:
       - name: Run RuboCop
         run: bundle exec rubocop --parallel
 
+      - name: Audit dependencies for known vulnerabilities
+        run: bundle exec bundler-audit check --update
+
   build:
     name: Build Gem
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+name: Publish
+
+# Primary release path: push a `vX.Y.Z` tag and this workflow builds, tests,
+# and publishes to RubyGems via Trusted Publishing (OIDC, no stored API key).
+#
+# `rake release` remains available as a manual fallback if CI is unavailable.
+# Running it locally will push a tag that also triggers this workflow; the
+# resulting `gem push` of an already-published version is rejected by
+# RubyGems harmlessly (this job fails visibly, no side effects).
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Run RSpec tests
+        run: bundle exec rspec --format documentation
+        env:
+          COOLHAND_ENV: test
+          COOLHAND_API_ENDPOINT: https://coolhand_api_endpoint
+          COOLHAND_API_KEY: coolhand_api_key-xxx-yyy-zzz
+          COOLHAND_SILENT: true
+          COOLHAND_INTERCEPT_ADDRESSES: open-ai-host
+
+      - name: Run RuboCop
+        run: bundle exec rubocop --parallel
+
+      - name: Build gem
+        run: gem build coolhand-ruby.gemspec
+
+      - name: Verify tag matches gemspec version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          GEM_VERSION="$(ruby -Ilib -e 'require "coolhand/version"; puts Coolhand::VERSION')"
+          if [ "$TAG_VERSION" != "$GEM_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match Coolhand::VERSION $GEM_VERSION"
+            exit 1
+          fi
+
+  publish:
+    name: Publish to RubyGems
+    needs: build
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Release gem via Trusted Publishing
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "faraday-typhoeus", "~> 1.1"
 gem "ruby-openai", "~> 8.3"
 
 group :development, :test do
+  gem "bundler-audit", "~> 0.9", require: false
   gem "simplecov", require: false
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,9 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     byebug (12.0.0)
     coderay (1.1.3)
     crack (1.0.1)
@@ -115,6 +118,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     test-prof (1.4.4)
+    thor (1.5.0)
     typhoeus (1.5.0)
       ethon (>= 0.9.0, < 0.16.0)
     unicode-display_width (3.2.0)
@@ -140,6 +144,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bundler-audit (~> 0.9)
   coolhand!
   faraday-typhoeus (~> 1.1)
   pry

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest published version of `coolhand` on RubyGems is supported with security fixes.
+Please upgrade to the latest version before reporting an issue.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report vulnerabilities privately using one of the following:
+
+- [GitHub Security Advisories](https://github.com/Coolhand-Labs/coolhand-ruby/security/advisories/new)
+  for this repository (preferred)
+- Email team@coolhandlabs.com
+
+Please include a description of the vulnerability, steps to reproduce, and the impact you believe
+it has. We aim to acknowledge reports within 3 business days and to provide a fix or mitigation
+plan within 30 days, depending on severity.


### PR DESCRIPTION
## What's new

- **Automated, tokenless RubyGems publishing**: `.github/workflows/publish.yml` now publishes on `v*.*.*` tag push using RubyGems Trusted Publishing (OIDC) via `rubygems/release-gem` — no long-lived API key stored anywhere. Tests and RuboCop run first in a `build` job before a separate `publish` job (scoped to a `rubygems-publish` GitHub Environment) ships the gem. The manual `rake release` flow still works as a fallback.
- **CI hardening**: `ci.yml` jobs now declare explicit `permissions: { contents: read }`, GitHub Actions are pinned to commit SHAs instead of floating tags, and a new `bundler-audit check --update` step gates on known vulnerabilities in dependencies.
- **New repo policy files**: `.github/dependabot.yml` (weekly updates for bundler and GitHub Actions), `SECURITY.md` (vulnerability reporting policy), and `.github/CODEOWNERS`.

## What changed

Releases move from manual, local `rake release` (relying on whatever RubyGems credentials sit on a maintainer's machine) to a CI-driven, OIDC-attested pipeline triggered by pushing a version tag, mirroring the same pattern recently added to coolhand-node.

## Breaking changes

None — this is CI/release tooling only, no `lib/` changes and no public API impact. Publishing via the new workflow will only work once the RubyGems Trusted Publisher and `rubygems-publish` GitHub Environment are configured on the registry/repo side (tracked separately, not part of this diff).