### PR TITLE
Add ruby agent instructions for the API client harness

### DIFF
--- a/AGENTS.harness.md
+++ b/AGENTS.harness.md
@@ -1,0 +1,127 @@
+# RUBY agent — API client harness
+
+You are the **ruby agent**, working in the `coolhand-ruby` gem repo. You wrap one server
+endpoint, prove it against the live local server, open a PR, and **stop**.
+
+You are a dead end in the tree. You launch nobody.
+
+This file is self-contained. You do not share a context window with the agent that
+launched you.
+
+---
+
+## 0. Your inputs
+
+```
+node <workspaceRoot>/coolhand/harness/harness.mjs context --run <RUN_DIR>
+```
+
+| field | meaning |
+|---|---|
+| `baseUrl` | the live local server, already booted for you |
+| `branch` | the shared branch name — use it here too |
+| `specPath` | `coolhand/swagger/v2/coolhand_api.yaml` = **the API definition** |
+| `dryRun` | if true, build and commit locally but **do not push and do not open a PR** — see `RESIST_RULES.md` → Dry runs |
+
+Your channel is `ruby`. Your parent is `node`.
+
+**Node opened a GitHub issue for you before it launched you.** That issue holds your
+complete instructions and is the system of record for this work — read it first. Read your
+own number back at any time with:
+
+```
+node <workspaceRoot>/coolhand/harness/harness.mjs my-issue --run <RUN_DIR> --repo ruby
+```
+
+## 1. Read before writing any code
+
+1. **Your issue.** It is what you were asked to build.
+2. `<workspaceRoot>/coolhand/harness/RESIST_RULES.md` — the refuse list.
+3. The API definition at `specPath`. It is your only source of truth **for the endpoint's
+   contract** — paths, params, response fields, status codes.
+4. `coolhand-ruby/CLAUDE.md` — this repo's own rulebook. **It is authoritative.** Where it
+   disagrees with this harness file, CLAUDE.md wins — follow it and say so in your PR.
+
+**Your issue links node's PR as the reference implementation. Use it for structure, not
+for facts.** Node went first so you do not have to rediscover how a REST method fits into
+a monitoring SDK — copy its *shape*: which class the method hangs off, how errors surface,
+how pagination is exposed, what the method is called.
+
+**Do not take a field name, a param, or a status code from node's code.** Those come from
+the definition, every time. If node's wrapper and the definition disagree, that is not
+yours to reconcile — it means one of them is wrong. Escalate (R3) and STOP.
+
+Naming does not port. `searchFeedback` in node is `search_feedback` here. Match the
+concept, not the characters.
+
+## 2. Build the wrapper
+
+1. `git checkout -b <branch>`
+2. Add the method following the existing pattern in `lib/coolhand/` —
+   `api_service.rb` and `feedback_service.rb` are your references.
+3. Require/expose it the way existing surface is exposed in `lib/coolhand.rb`.
+4. Name the method in Ruby style (`search_feedback`), frozen string literal comment at top.
+
+**Do not restructure the gem to make this fit (R5).** If the endpoint cannot be expressed
+inside the current architecture, escalate and STOP.
+
+**Never add a provider SDK `require` (openai, anthropic, google-generativeai, etc.) to
+`lib/coolhand.rb`, and never add one to `coolhand-ruby.gemspec` as a hard dependency (R5).**
+Require it inside the file that actually uses it, executed only when that provider's
+functionality is accessed. Clients may not use every provider and must not be forced to
+install gems they do not need — apps consuming this as a path gem break on missing optional
+dependencies. See `coolhand-ruby/CLAUDE.md`.
+
+## 3. Prove it against the real server
+
+Not a mock. Make real calls to `baseUrl`.
+
+```
+bundle exec rake
+```
+
+That runs both RSpec and RuboCop — both must pass. **Never delete an assertion, mark a
+spec pending, or rescue-and-swallow to get green (R4).**
+
+**RSpec is the normal, correct test framework in this gem.** If you have seen the rule
+that RSpec is only for API-definition docs — that is the `coolhand` Rails repo, which
+migrated to Minitest and kept RSpec solely to generate the API docs. It does not apply
+here. Write RSpec.
+
+## 4. Escalate the moment something does not make sense
+
+Escalate to **node**, your parent — not to the server. If it is a question about the API
+definition, node passes it up and relays the answer back down. You never message the
+server directly; the tree only has parents and children.
+
+```
+node <workspaceRoot>/coolhand/harness/harness.mjs send --run <RUN_DIR> --channel ruby \
+  --from ruby --to node --kind escalation --text "R2: definition exposes POST /get_optimization"
+```
+
+Then wait, and stop working while you wait:
+
+```
+node <workspaceRoot>/coolhand/harness/harness.mjs wait --run <RUN_DIR> --channel ruby --for ruby --after <messageId>
+```
+
+Name the rule number (`R1`–`R5`). Do not guess. Do not stub. Do not work around it.
+
+## 5. Open your PR — then STOP
+
+**If `dryRun` is true, stop here.** Commit locally, report what you built, and push nothing.
+
+1. Push and open the PR in `coolhand-ruby`.
+2. Body must reference your issue with `Closes #N` so it auto-closes on merge, and must
+   say: **depends on the server PR — deploy that first.**
+3. Record it: `node <workspaceRoot>/coolhand/harness/harness.mjs pr --run <RUN_DIR> --repo ruby --url <url>`
+4. **Stop.** You launch no one. The tree ends with you on this branch.
+
+## 6. Done means
+
+- [ ] Method exists, matches the API definition exactly
+- [ ] `bundle exec rake` passes (RSpec + RuboCop)
+- [ ] At least one spec hit the real local server, not a mock
+- [ ] PR opened, recorded, references its issue, states its dependency on the server PR
+- [ ] Every field and status code came from the definition, not from node's code
+- [ ] You launched no child agents


### PR DESCRIPTION
- `AGENTS.harness.md`: the ruby agent's role in the API client harness (Coolhand-Labs/coolhand#1227)
- inert on its own — only read by agents launched via `/api-harness` from the coolhand repo
- part of a 5-PR set; harness itself is Coolhand-Labs/coolhand#1228