### PR TITLE
fix(deps): bump json to 2.21.2 (GHSA-9hj4-r449-hfvc)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
     hashdiff (1.2.1)
-    json (2.20.0)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)


### PR DESCRIPTION
- `bundler-audit` fails on every PR: `json 2.20.0`, CVE-2026-71847, needs `>= 2.21.2`
- advisory published 2026-08-07; main is equally vulnerable, just hasn't re-run CI since 08-02
- `json` is transitive (rubocop, faraday) — not in Gemfile or gemspec
- `bundle lock --update=json`, one line, no source changes
- note: dependabot can't open this itself — resolves against Ruby 3.0.7 (gemspec floor, no `.ruby-version`) where `bundler-audit ~> 0.9` is unsatisfiable, so all bundler update runs error `dependency_file_not_resolvable`
- unblocks #92