### PR TITLE
Stop printing full request/webhook body to stdout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **The full captured request/webhook body is no longer printed to stdout by default.** `Coolhand::ApiService#log_request_info` (reached via `LoggerService#log_to_api`/`#forward_webhook`) previously dumped the entire captured payload — including raw webhook bodies like voice-call transcripts — to stdout whenever `silent` was `false` (the default). In a containerized deploy, stdout typically flows straight into a log aggregator with a different retention/access model than Coolhand itself. It now logs only an identifier and a byte count by default; the full payload is still printed when `debug_mode` is explicitly enabled (#87).
+
 ## [0.5.1] - 2026-08-02
 
 ### Added

--- a/lib/coolhand/api_service.rb
+++ b/lib/coolhand/api_service.rb
@@ -281,8 +281,24 @@ module Coolhand
       return if silent
 
       puts "\n🎉 LOGGING OpenAI API Call #{@api_endpoint}"
-      puts captured_data
+
+      if debug_mode?
+        puts captured_data
+      else
+        puts request_body_summary(captured_data)
+      end
+
       puts "📤 Sending to: #{@api_endpoint}"
+    end
+
+    def request_body_summary(captured_data)
+      return "captured_data: (unavailable)" unless captured_data.is_a?(Hash)
+
+      id = captured_data[:id] || captured_data["id"] || "N/A"
+      body = captured_data[:request_body] || captured_data["request_body"]
+      "id: #{id}, request_body: #{body.to_json.bytesize} bytes"
+    rescue StandardError
+      "captured_data: (unavailable)"
     end
   end
 end

--- a/spec/coolhand/logger_service_spec.rb
+++ b/spec/coolhand/logger_service_spec.rb
@@ -141,6 +141,65 @@ RSpec.describe Coolhand::LoggerService do
           expect { verbose_service.log_to_api(captured_data) }
             .to output(/🎉 LOGGING OpenAI/).to_stdout
         end
+
+        it "logs an identifier and byte count instead of the full request body" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          pii_captured_data = captured_data.merge(
+            request_body: { transcript: [{ role: "user", message: "my SSN is 123-45-6789" }] }
+          )
+
+          expect { verbose_service.log_to_api(pii_captured_data) }
+            .to output(/id: uuid-123, request_body: \d+ bytes/).to_stdout
+
+          expect { verbose_service.log_to_api(pii_captured_data) }
+            .not_to output(/123-45-6789/).to_stdout
+        end
+
+        it "does not raise and logs a placeholder when captured_data is not a Hash" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          expect { verbose_service.log_to_api("not a hash") }
+            .not_to raise_error
+
+          expect { verbose_service.log_to_api("not a hash") }
+            .to output(/captured_data: \(unavailable\)/).to_stdout
+        end
+
+        it "falls back to defaults when captured_data is missing id/request_body keys" do
+          stub_request(:post, "https://coolhandlabs.com/api/v2/llm_request_logs")
+            .to_return(status: 200, body: JSON.generate({ id: 123 }))
+
+          expect { verbose_service.log_to_api({}) }
+            .to output(%r{id: N/A, request_body: \d+ bytes}).to_stdout
+        end
+
+        context "when debug_mode is enabled" do
+          let(:debug_config) do
+            instance_double(Coolhand::Configuration,
+              api_key: "test-api-key",
+              base_url: "https://coolhandlabs.com/api",
+              silent: false,
+              environment: "production",
+              debug_mode: true)
+          end
+
+          let(:debug_service) do
+            allow(Coolhand).to receive(:configuration).and_return(debug_config)
+            described_class.new
+          end
+
+          it "still logs the full captured data" do
+            pii_captured_data = captured_data.merge(
+              request_body: { transcript: [{ role: "user", message: "my SSN is 123-45-6789" }] }
+            )
+
+            expect { debug_service.log_to_api(pii_captured_data) }
+              .to output(/123-45-6789/).to_stdout
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What's new

`Coolhand::ApiService#log_request_info` no longer dumps the entire captured request/webhook payload to stdout by default. Previously, any time `silent` was `false` (the default), the full captured body — including raw webhook bodies like voice-call transcripts, which can carry PII — was printed via `puts`. In a containerized deploy that output typically flows straight into a log aggregator with a different retention/access model than Coolhand itself.

## What changed

Outside `debug_mode`, only a summary line (`id: <id>, request_body: <n> bytes`) is now printed. The full payload is still printed when `debug_mode` is explicitly enabled, matching the posture already used by the interceptor logging path. The new summary helper safely handles non-`Hash`/malformed captured data without raising, so it can't break a host app's webhook-forwarding request path. The actual payload sent to the Coolhand API is unchanged — only local stdout output is affected.

## Breaking changes

None — this only changes local console output shape, not the public interface or the API payload.

[closes #87]