### PR TITLE
Fix webhook validation env check: blocklist to fail-safe allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **`Coolhand::OpenAi::WebhookValidator#should_enforce_strict_validation?` no longer fails open on unrecognized `Rails.env` names.** It previously blocklisted `"production"`/`"staging"` exactly, so any other spelling — `"prod"`, `"production-eu"`, a Heroku/Render `"review"` app env, or an unset `Rails.env` — fell into the permissive fallback path, where a missing/misconfigured webhook secret let an unsigned request pass as valid. It now uses a fail-safe allowlist of `"development"`/`"test"` — every other value, including `nil`, enforces strict validation (#84).
+
 ## [0.5.1] - 2026-08-02
 
 ### Added

--- a/lib/coolhand/open_ai/webhook_validator.rb
+++ b/lib/coolhand/open_ai/webhook_validator.rb
@@ -40,7 +40,8 @@ module Coolhand
         return true if @payload
 
         if should_enforce_strict_validation?
-          @errors << "Empty webhook payload - rejecting webhook in production/staging"
+          @errors << "Empty webhook payload - rejecting webhook (Rails.env=#{Rails.env.inspect} " \
+                     "not in development/test allowlist)"
           Rails.logger.error(@errors.last)
           false
         else
@@ -51,7 +52,8 @@ module Coolhand
 
       def validate_in_non_production_env
         if should_enforce_strict_validation?
-          @errors << "OpenAI webhook secret not configured - rejecting webhook in production/staging"
+          @errors << "OpenAI webhook secret not configured - rejecting webhook (Rails.env=#{Rails.env.inspect} " \
+                     "not in development/test allowlist)"
           Rails.logger.error(@errors.last)
           false
         else
@@ -81,7 +83,7 @@ module Coolhand
       def validate_headers_in_non_production_env
         if should_enforce_strict_validation?
           @errors << "Missing OpenAI webhook signature or timestamp headers - " \
-                     "rejecting webhook in production/staging"
+                     "rejecting webhook (Rails.env=#{Rails.env.inspect} not in development/test allowlist)"
           Rails.logger.error(@errors.last)
           false
         else
@@ -124,7 +126,7 @@ module Coolhand
       end
 
       def should_enforce_strict_validation?
-        ["production", "staging"].include?(Rails.env)
+        !%w[development test].include?(Rails.env)
       end
     end
   end

--- a/spec/coolhand/open_ai/webhook_validator_spec.rb
+++ b/spec/coolhand/open_ai/webhook_validator_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Coolhand::OpenAi::WebhookValidator do
       end
     end
 
-    context "when Rails.env is not production/staging (permissive fallback path)" do
+    context "when Rails.env is in the development/test allowlist (permissive fallback path)" do
       before do
         allow(Rails).to receive(:env).and_return("development")
         allow(Rails.logger).to receive(:warn)
@@ -236,6 +236,17 @@ RSpec.describe Coolhand::OpenAi::WebhookValidator do
 
         it "allows the webhook through and warns instead of rejecting" do
           expect(Rails.logger).to receive(:warn).with(/skipping signature verification in development/)
+          expect(validator.valid?).to be true
+        end
+      end
+
+      context "when Rails.env is \"test\"" do
+        let(:webhook_secret) { nil }
+
+        before { allow(Rails).to receive(:env).and_return("test") }
+
+        it "also allows the webhook through and warns instead of rejecting" do
+          expect(Rails.logger).to receive(:warn).with(/skipping signature verification in test/)
           expect(validator.valid?).to be true
         end
       end
@@ -274,6 +285,32 @@ RSpec.describe Coolhand::OpenAi::WebhookValidator do
         it "allows the webhook through and warns instead of rejecting" do
           expect(Rails.logger).to receive(:warn).with(/allowing in development environment/)
           expect(validator.valid?).to be true
+        end
+      end
+    end
+
+    context "when Rails.env is an unrecognized or unset name (must default to strict)" do
+      let(:webhook_secret) { nil }
+
+      before { allow(Rails.logger).to receive(:error) }
+
+      %w[prod production-eu review staging production].each do |env_name|
+        context "when Rails.env is #{env_name.inspect}" do
+          before { allow(Rails).to receive(:env).and_return(env_name) }
+
+          it "rejects the webhook instead of falling back to the permissive path" do
+            expect(Rails.logger).to receive(:error).with(/not configured - rejecting webhook/)
+            expect(validator.valid?).to be false
+          end
+        end
+      end
+
+      context "when Rails.env is nil (unset)" do
+        before { allow(Rails).to receive(:env).and_return(nil) }
+
+        it "rejects the webhook instead of falling back to the permissive path" do
+          expect(Rails.logger).to receive(:error).with(/not configured - rejecting webhook/)
+          expect(validator.valid?).to be false
         end
       end
     end


### PR DESCRIPTION
[closes #84]

**What changed:** `WebhookValidator#should_enforce_strict_validation?` previously blocklisted only `"production"`/`"staging"` exactly, so any other `Rails.env` spelling — `"prod"`, `"production-eu"`, Heroku/Render review-app envs, or an unset env — silently fell into the permissive fallback path, where a missing/misconfigured webhook secret let an unsigned request pass as valid. It now uses a fail-safe allowlist of `"development"`/`"test"`; every other value, including `nil`, enforces strict validation. The three related error-message strings were also updated to drop the now-inaccurate "production/staging" wording.

**What's new:** No new public API. Spec coverage added for the `"test"` env (permissive) and for previously-permissive-but-now-strict env names (`"prod"`, `"production-eu"`, `"review"`, `"staging"`, `"production"`, unset).

**Breaking changes:** None for typical deployments (anything spelled `"production"` or `"staging"` behaves identically). Deployments running with an unrecognized `Rails.env` string that previously relied on the permissive fallback will now see strict enforcement — this is the intended fix, not a regression.