### PR TITLE
Fix NetHttpInterceptor patch state race across threads [closes #90]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **`NetHttpInterceptor`'s patched/unpatched state is no longer a plain boolean shared across threads.** `Coolhand.capture` snapshotted `NetHttpInterceptor.patched?` before yielding and used that snapshot at the end of a potentially long-running block (an in-flight HTTP request) to decide whether to unpatch. Two threads concurrently entering `Coolhand.capture` before the interceptor was already permanently patched could both observe `patched? == false`, and whichever thread's block finished first would call `unpatch!`, silently disabling interception for the other thread's still in-flight request. `patch!`/`unpatch!` are now a mutex-guarded reference count, so overlapping/nested callers compose correctly and the interceptor only actually unpatches once every outstanding caller has released it (#90). One behavior change: `patch!` is no longer idempotent on its own — every call now needs a matching `unpatch!` to release it, so an app that calls `Coolhand.configure` more than once (e.g. a reloader re-running an initializer) holds an extra, permanent reference each time rather than no-op'ing. This is harmless (interception simply stays on) but is a change from the prior behavior.
+
 ## [0.5.1] - 2026-08-02
 
 ### Added

--- a/lib/coolhand.rb
+++ b/lib/coolhand.rb
@@ -62,12 +62,11 @@ module Coolhand
 
       return yield unless configuration.enabled
 
-      patched = NetHttpInterceptor.patched?
       NetHttpInterceptor.patch!
       begin
         yield
       ensure
-        NetHttpInterceptor.unpatch! unless patched
+        NetHttpInterceptor.unpatch!
       end
     end
 

--- a/lib/coolhand/net_http_interceptor.rb
+++ b/lib/coolhand/net_http_interceptor.rb
@@ -24,25 +24,67 @@ module Coolhand
       end
     end
 
+    @patch_mutex = Mutex.new
+    @patch_count = 0
+    @patched = false
+
+    # patch!/unpatch! are reference-counted so concurrent/nested callers (e.g. overlapping
+    # Coolhand.capture blocks across threads) compose safely — the interceptor only actually
+    # unpatches once every outstanding caller has released it. Coolhand.configure's patch! is
+    # never balanced by an unpatch!, so it permanently holds the count at >=1 for the process
+    # lifetime once the gem is enabled; that's intentional, not a leak.
+    #
+    # Unlike before, patch! is no longer idempotent on its own — every call must be matched by
+    # exactly one unpatch! to release it. A host app that calls Coolhand.configure more than once
+    # (e.g. a reloader re-running an initializer) will hold an extra, permanent reference each
+    # time rather than no-op'ing; harmless (interception simply stays on), but worth knowing.
     def self.patch!
-      return if @patched
+      @patch_mutex.synchronize do
+        @patch_count += 1
+        next if @patched
 
-      Net::HTTP.prepend(self)
-      Net::HTTPResponse.prepend(ResponseInterceptor)
+        begin
+          Net::HTTP.prepend(self)
+          Net::HTTPResponse.prepend(ResponseInterceptor)
 
-      @patched = true
-      Coolhand.log "🔗 Net::HTTP interceptor patched"
+          @patched = true
+          Coolhand.log "🔗 Net::HTTP interceptor patched"
+        rescue StandardError
+          # Roll back this call's hold — it never actually took effect, so it must not count
+          # toward the refcount or a legitimate later unpatch! would underflow against it. This
+          # branch only runs when @patched was false on entry (see `next if @patched` above), so
+          # forcing it back to false here is correct regardless of which line above raised —
+          # including a failure in the log call itself, after prepend already succeeded.
+          @patch_count -= 1
+          @patched = false
+          raise
+        end
+      end
     end
 
     def self.unpatch!
       # NOTE: With prepend, there's no clean way to unpatch
       # We'll mark it as unpatched so it can be re-patched
-      @patched = false
-      Coolhand.log "🔌 Faraday monitoring disabled ..."
+      @patch_mutex.synchronize do
+        @patch_count -= 1 if @patch_count.positive?
+        next if @patch_count.positive? || !@patched
+
+        @patched = false
+        Coolhand.log "🔌 Faraday monitoring disabled ..."
+      end
     end
 
     def self.patched?
       @patched
+    end
+
+    # Testing-only: force a clean slate. Real callers should only ever use balanced
+    # patch!/unpatch! pairs.
+    def self.reset!
+      @patch_mutex.synchronize do
+        @patch_count = 0
+        @patched = false
+      end
     end
 
     def request(req, body = nil, &block)

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Coolhand do
       called = false
 
       expect(Coolhand::NetHttpInterceptor).to receive(:patch!).ordered
-      expect(Coolhand::NetHttpInterceptor).not_to receive(:unpatch!).ordered
+      expect(Coolhand::NetHttpInterceptor).to receive(:unpatch!).ordered
 
       Coolhand.capture do
         called = true

--- a/spec/coolhand/net_http_interceptor_spec.rb
+++ b/spec/coolhand/net_http_interceptor_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "webmock/rspec"
 require "net/http"
 require "stringio"
+require "timeout"
 
 RSpec.describe Coolhand::NetHttpInterceptor do
   let(:api_service_instance) { instance_double(Coolhand::ApiService) }
@@ -245,16 +246,106 @@ RSpec.describe Coolhand::NetHttpInterceptor do
 
       expect(Net::HTTP.ancestors).to include(described_class)
     end
+
+    it "rolls back both the refcount and the patched flag when the underlying patch step raises" do
+      described_class.reset!
+      allow(Coolhand).to receive(:log).with(/patched/).and_raise("boom from log")
+
+      expect { described_class.patch! }.to raise_error("boom from log")
+
+      expect(described_class.patched?).to be false
+
+      # A subsequent, successful patch!/unpatch! pair must still balance cleanly — proves the
+      # failed call above left no leaked refcount behind.
+      allow(Coolhand).to receive(:log).and_call_original
+      described_class.patch!
+      expect(described_class.patched?).to be true
+      described_class.unpatch!
+      expect(described_class.patched?).to be false
+    end
   end
 
   describe ".unpatch!" do
     it "marks the interceptor as unpatched so guarded requests fall through to the real implementation" do
+      described_class.reset!
       described_class.patch!
       expect(described_class.patched?).to be true
 
       described_class.unpatch!
 
       expect(described_class.patched?).to be false
+    end
+
+    it "stays patched while a second overlapping patch! is still outstanding" do
+      described_class.reset!
+      described_class.patch! # outer holder starts
+      described_class.patch! # inner overlapping holder starts
+
+      described_class.unpatch! # inner finishes first
+      expect(described_class.patched?).to be true
+
+      described_class.unpatch! # outer finishes
+      expect(described_class.patched?).to be false
+    end
+
+    it "does not log a spurious 'disabled' message on an unbalanced extra unpatch! call" do
+      described_class.reset!
+
+      described_class.unpatch! # no matching patch! — a caller bug, but must be a harmless no-op
+
+      expect(described_class.patched?).to be false
+      expect(Coolhand).not_to have_received(:log).with(/disabled/)
+    end
+  end
+
+  # Integration-level sanity check that Coolhand.capture composes correctly across threads.
+  # This does NOT reproduce the original TOCTOU race itself (that requires two threads reading
+  # a stale `patched?` snapshot at the same instant, which can't be forced deterministically
+  # through the public API) — the deterministic regression coverage for the race is the
+  # ".unpatch!" example above ("stays patched while a second overlapping patch! is still
+  # outstanding").
+  describe "overlapping Coolhand.capture blocks" do
+    it "keeps requests intercepted for an overlapping in-flight capture block" do
+      described_class.reset!
+      stub_request(:get, "https://api.test.com/hello")
+        .to_return(status: 200, body: '{"msg":"hi"}', headers: { "Content-Type" => "application/json" })
+
+      release_outer = Queue.new
+      outer_started = Queue.new
+
+      outer = Thread.new do
+        Coolhand.capture do
+          outer_started << true
+          release_outer.pop
+        end
+      end
+
+      begin
+        # Bounded, not an unbounded #pop: if the outer thread's Coolhand.capture block raised
+        # before ever reaching `outer_started << true` (e.g. patch! itself failed), we'd
+        # otherwise block here forever with no way to reach the `ensure` below.
+        Timeout.timeout(2) { outer_started.pop }
+        expect(Coolhand::NetHttpInterceptor.patched?).to be true
+
+        uri = URI("https://api.test.com/hello")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        # Synchronous: NetHttpInterceptor#request calls the stubbed ApiService synchronously
+        # (see the `before` block above), so @captured_log is populated before capture returns.
+        Coolhand.capture { http.request(Net::HTTP::Get.new(uri)) }
+
+        expect(@captured_log).to be_a(Hash)
+        expect(Coolhand::NetHttpInterceptor.patched?).to be true
+      ensure
+        # Always release and join the outer thread, even if an assertion above failed, so a
+        # failing example doesn't leak a thread blocked forever on release_outer.pop. Bounded
+        # with a timeout + kill as a last resort in case the outer thread is wedged some other way.
+        release_outer << true
+        outer.join(2)
+        outer.kill if outer.alive?
+      end
+
+      expect(Coolhand::NetHttpInterceptor.patched?).to be false
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,5 +18,6 @@ RSpec.configure do |config|
   # Reset configuration before each test to avoid state pollution
   config.before(:each) do
     Coolhand.reset_configuration!
+    Coolhand::NetHttpInterceptor.reset!
   end
 end


### PR DESCRIPTION
## What's new
- `Coolhand::NetHttpInterceptor` gains a test-only `.reset!` for clean state between examples.

## What changed
- `NetHttpInterceptor.patch!`/`.unpatch!` are now a mutex-guarded reference count instead of a plain boolean shared across threads. Previously, `Coolhand.capture` snapshotted `patched?` before yielding and used that stale snapshot afterward to decide whether to unpatch — two threads concurrently entering `Coolhand.capture` before the interceptor was already permanently patched could both observe `patched? == false`, and whichever thread's block finished first would call `unpatch!`, silently disabling interception for the other thread's still in-flight request. Overlapping/nested `Coolhand.capture` callers now compose correctly, and a failed `patch!` (e.g. a raising prepend or log call) rolls back cleanly instead of leaking refcount state.
- `Coolhand.capture` simplified to always call `patch!`/`unpatch!` symmetrically, delegating correctness to the interceptor's own refcount rather than its own ad-hoc bookkeeping.

## Breaking changes
None for typical usage. One behavior nuance: `patch!` is no longer idempotent on its own — every call now needs a matching `unpatch!` to release it, so an app that calls `Coolhand.configure` more than once (e.g. a reloader re-running an initializer) holds an extra, permanent reference each time rather than no-op'ing. Harmless — interception simply stays on.

[closes #90]