### PR TITLE
Add OpenCode to default intercept addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OpenCode added to default intercept addresses** — `opencode.ai` (OpenCode Zen's OpenAI-compatible gateway) is now monitored out of the box with no configuration required. Since matching is substring-based, this also covers requests to `api.opencode.ai` (a host with no real OpenCode endpoint, but one we've observed real client traffic hitting) without needing a separate entry, so misrouted requests show up in logs instead of vanishing (#97).
+
 ## [0.5.1] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ The monitor works with multiple transport layers and Ruby libraries:
 - AWS Bedrock (OpenAI-compatible endpoint)
 - Cloudflare AI Gateway
 - OpenRouter
+- OpenCode Zen (`opencode.ai`)
 
 **Universal Coverage**: Since most Ruby HTTP libraries use Net::HTTP under the hood, Coolhand's single interceptor provides comprehensive monitoring without needing library-specific integrations.
 

--- a/lib/coolhand/default_intercept_addresses.yml
+++ b/lib/coolhand/default_intercept_addresses.yml
@@ -17,3 +17,4 @@
 - "gateway.ai.cloudflare.com"
 - "bedrock-runtime"
 - "openrouter.ai"
+- "opencode.ai"

--- a/spec/coolhand/coolhand_spec.rb
+++ b/spec/coolhand/coolhand_spec.rb
@@ -351,6 +351,19 @@ RSpec.describe Coolhand do
     end
   end
 
+  describe "OpenCode default configuration" do
+    it "includes opencode.ai in default intercept_addresses" do
+      fresh_config = Coolhand::Configuration.new
+      expect(fresh_config.intercept_addresses).to include("opencode.ai")
+    end
+
+    it "captures the misconfigured api.opencode.ai host via substring match, no separate entry needed" do
+      fresh_config = Coolhand::Configuration.new
+      matching_address = fresh_config.intercept_addresses.find { |a| "https://api.opencode.ai/v1/chat/completions".include?(a) }
+      expect(matching_address).to eq("opencode.ai")
+    end
+  end
+
   describe ".required_field?" do
     it "returns true for valid values" do
       expect(Coolhand.required_field?("valid")).to be true


### PR DESCRIPTION
## Added
- **OpenCode Zen support** — `opencode.ai` (OpenCode Zen's OpenAI-compatible model gateway) is now monitored out of the box, no configuration required. Since matching is substring-based, this single entry also covers `api.opencode.ai`, a misconfigured host with no real OpenCode endpoint that we've observed in real client traffic — so misrouted requests show up in logs instead of vanishing silently.

## Changed
- README's "Other providers monitored out of the box" list now includes OpenCode Zen.

No breaking changes — this is purely additive to the default intercept address list, and no previously-covered host was dropped.

[closes #97]